### PR TITLE
Improve Workgroup Backoff strategy

### DIFF
--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/BaseHandlerStd.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/BaseHandlerStd.java
@@ -3,7 +3,6 @@ package software.amazon.redshiftserverless.workgroup;
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
 import software.amazon.awssdk.services.redshiftserverless.model.DeleteWorkgroupRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupRequest;
-import software.amazon.awssdk.services.redshiftserverless.model.RedshiftServerlessRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.RedshiftServerlessResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.redshiftserverless.model.WorkgroupStatus;
@@ -20,13 +19,8 @@ import java.time.Duration;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
-    protected static final Constant DELETE_BACKOFF_STRATEGY = Constant.of()
-            .timeout(Duration.ofMinutes(5L))
-            .delay(Duration.ofSeconds(5L))
-            .build();
-
-    protected static final Constant UPDATE_BACKOFF_STRATEGY = Constant.of()
-            .timeout(Duration.ofMinutes(20L))
+    protected static final Constant BACKOFF_STRATEGY = Constant.of()
+            .timeout(Duration.ofMinutes(30L))
             .delay(Duration.ofSeconds(5L))
             .build();
 
@@ -62,11 +56,11 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 .build();
 
         try {
-            String workgroupStatus = proxyClient.injectCredentialsAndInvokeV2(getStatusRequest, proxyClient.client()::getWorkgroup)
+            WorkgroupStatus workgroupStatus = proxyClient.injectCredentialsAndInvokeV2(getStatusRequest, proxyClient.client()::getWorkgroup)
                     .workgroup()
-                    .statusAsString();
+                    .status();
 
-            return workgroupStatus.equalsIgnoreCase(WorkgroupStatus.AVAILABLE.toString());
+            return workgroupStatus.equals(WorkgroupStatus.AVAILABLE);
 
         } catch (ResourceNotFoundException e) {
             return awsRequest instanceof DeleteWorkgroupRequest;

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/ClientBuilder.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/ClientBuilder.java
@@ -11,7 +11,7 @@ public class ClientBuilder {
     // TODO: change the endpoint when it goes to prod
     public static RedshiftServerlessClient getClient() {
         return RedshiftServerlessClient.builder()
-                .endpointOverride(URI.create("https://devo.us-east-1.serverless.redshift.aws.a2z.com"))
+                .endpointOverride(URI.create("https://qa.us-east-1.serverless.redshift.aws.a2z.com"))
                 .region(Region.US_EAST_1)
                 .httpClient(LambdaWrapper.HTTP_CLIENT)
                 .build();

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/DeleteHandler.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/DeleteHandler.java
@@ -30,7 +30,7 @@ public class DeleteHandler extends BaseHandlerStd {
                 .then(progress ->
                         proxy.initiate("AWS-RedshiftServerless-Workgroup::Delete", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
                                 .translateToServiceRequest(Translator::translateToDeleteRequest)
-                                .backoffDelay(DELETE_BACKOFF_STRATEGY)
+                                .backoffDelay(BACKOFF_STRATEGY)
                                 .makeServiceCall(this::deleteWorkgroup)
                                 .stabilize(this::isWorkgroupStable)
                                 .handleError(this::deleteWorkgroupErrorHandler)

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/UpdateHandler.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/UpdateHandler.java
@@ -70,6 +70,7 @@ public class UpdateHandler extends BaseHandlerStd {
                 .then(progress ->
                         proxy.initiate("AWS-RedshiftServerless-Workgroup::Update::UpdateTags", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
                                 .translateToServiceRequest(resourceModel -> Translator.translateToUpdateTagsRequest(request.getDesiredResourceState(), resourceModel))
+                                .backoffDelay(BACKOFF_STRATEGY)
                                 .makeServiceCall(this::updateTags)
                                 .stabilize(this::isWorkgroupStable)
                                 .handleError(this::operateTagsErrorHandler)
@@ -78,7 +79,7 @@ public class UpdateHandler extends BaseHandlerStd {
                 .then(progress ->
                         proxy.initiate("AWS-RedshiftServerless-Workgroup::Update::UpdateInstance", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
                                 .translateToServiceRequest(Translator::translateToUpdateRequest)
-                                .backoffDelay(UPDATE_BACKOFF_STRATEGY)
+                                .backoffDelay(BACKOFF_STRATEGY)
                                 .makeServiceCall(this::updateWorkgroup)
                                 .stabilize(this::isWorkgroupStable)
                                 .handleError(this::updateWorkgroupErrorHandler)

--- a/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/AbstractTestBase.java
+++ b/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/AbstractTestBase.java
@@ -11,6 +11,7 @@ import software.amazon.awssdk.services.redshiftserverless.model.DeleteWorkgroupR
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.ListWorkgroupsResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.UpdateWorkgroupResponse;
+import software.amazon.awssdk.services.redshiftserverless.model.WorkgroupStatus;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Credentials;
 import software.amazon.cloudformation.proxy.LoggerProxy;
@@ -31,7 +32,7 @@ public class AbstractTestBase {
     private static final String WORKGROUP_ARN;
     private static final int BASE_CAPACITY;
     private static final int UPDATED_BASE_CAPACITY;
-    private static final String STATUS;
+    private static final WorkgroupStatus STATUS;
     private static final List<String> SUBNET_IDS;
     private static final List<String> SECURITY_GROUP_IDS;
     private static final Set<ConfigParameter> CONFIG_PARAMETERS;
@@ -47,7 +48,7 @@ public class AbstractTestBase {
         WORKGROUP_ARN = "DUMMY_WORKGROUP_ARN";
         BASE_CAPACITY = 0;
         UPDATED_BASE_CAPACITY = 0;
-        STATUS = "available";
+        STATUS = WorkgroupStatus.AVAILABLE;
         SUBNET_IDS = Collections.emptyList();
         SECURITY_GROUP_IDS = Collections.emptyList();
         CONFIG_PARAMETERS = Collections.emptySet();
@@ -115,7 +116,7 @@ public class AbstractTestBase {
                         .workgroupName(WORKGROUP_NAME)
                         .namespaceName(NAMESPACE_NAME)
                         .workgroupArn(WORKGROUP_ARN)
-                        .status(STATUS)
+                        .status(STATUS.toString())
                         .baseCapacity(BASE_CAPACITY)
                         .securityGroupIds(SECURITY_GROUP_IDS)
                         .subnetIds(SUBNET_IDS)
@@ -184,6 +185,7 @@ public class AbstractTestBase {
         return CreateWorkgroupResponse.builder()
                 .workgroup(software.amazon.awssdk.services.redshiftserverless.model.Workgroup.builder()
                         .workgroupName(WORKGROUP_NAME)
+                        .status(STATUS)
                         .build())
                 .build();
     }
@@ -196,6 +198,7 @@ public class AbstractTestBase {
         return UpdateWorkgroupResponse.builder()
                 .workgroup(software.amazon.awssdk.services.redshiftserverless.model.Workgroup.builder()
                         .workgroupName(WORKGROUP_NAME)
+                        .status(STATUS)
                         .build())
                 .build();
     }


### PR DESCRIPTION
*Issue #, if available:*
- Delete backoff strategy was set as 5 minutes. Sometimes, it's not long enough

*Description of changes:*
- Extend the timeout

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
