### PR TITLE
Resource Policy Integration with Namespace

### DIFF
--- a/aws-redshiftserverless-namespace/aws-redshiftserverless-namespace.json
+++ b/aws-redshiftserverless-namespace/aws-redshiftserverless-namespace.json
@@ -171,6 +171,10 @@
         "FinalSnapshotRetentionPeriod": {
             "description": "The number of days to retain automated snapshot in the destination region after they are copied from the source region. If the value is -1, the manual snapshot is retained indefinitely. The value must be either -1 or an integer between 1 and 3,653.",
             "type": "integer"
+        },
+        "NamespaceResourcePolicy": {
+            "description": "The resource policy document that will be attached to the namespace.",
+            "type": "object"
         }
     },
     "tagging": {
@@ -223,13 +227,16 @@
                 "kms:ListGrants",
                 "kms:RevokeGrant",
                 "redshift-serverless:CreateNamespace",
-                "redshift-serverless:GetNamespace"
+                "redshift-serverless:GetNamespace",
+                "redshift:GetResourcePolicy",
+                "redshift:PutResourcePolicy"
             ]
         },
         "read": {
             "permissions": [
                 "iam:PassRole",
-                "redshift-serverless:GetNamespace"
+                "redshift-serverless:GetNamespace",
+                "redshift:GetResourcePolicy"
             ]
         },
         "update": {
@@ -246,7 +253,9 @@
                 "kms:ListGrants",
                 "kms:RevokeGrant",
                 "redshift-serverless:UpdateNamespace",
-                "redshift-serverless:GetNamespace"
+                "redshift-serverless:GetNamespace",
+                "redshift:PutResourcePolicy",
+                "redshift:DeleteResourcePolicy"
             ]
         },
         "delete": {

--- a/aws-redshiftserverless-namespace/docs/README.md
+++ b/aws-redshiftserverless-namespace/docs/README.md
@@ -22,7 +22,8 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#namespacename" title="NamespaceName">NamespaceName</a>" : <i>String</i>,
         "<a href="#tags" title="Tags">Tags</a>" : <i>[ <a href="tag.md">Tag</a>, ... ]</i>,
         "<a href="#finalsnapshotname" title="FinalSnapshotName">FinalSnapshotName</a>" : <i>String</i>,
-        "<a href="#finalsnapshotretentionperiod" title="FinalSnapshotRetentionPeriod">FinalSnapshotRetentionPeriod</a>" : <i>Integer</i>
+        "<a href="#finalsnapshotretentionperiod" title="FinalSnapshotRetentionPeriod">FinalSnapshotRetentionPeriod</a>" : <i>Integer</i>,
+        "<a href="#namespaceresourcepolicy" title="NamespaceResourcePolicy">NamespaceResourcePolicy</a>" : <i>Map</i>
     }
 }
 </pre>
@@ -46,6 +47,7 @@ Properties:
       - <a href="tag.md">Tag</a></i>
     <a href="#finalsnapshotname" title="FinalSnapshotName">FinalSnapshotName</a>: <i>String</i>
     <a href="#finalsnapshotretentionperiod" title="FinalSnapshotRetentionPeriod">FinalSnapshotRetentionPeriod</a>: <i>Integer</i>
+    <a href="#namespaceresourcepolicy" title="NamespaceResourcePolicy">NamespaceResourcePolicy</a>: <i>Map</i>
 </pre>
 
 ## Properties
@@ -179,6 +181,16 @@ The number of days to retain automated snapshot in the destination region after 
 _Required_: No
 
 _Type_: Integer
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### NamespaceResourcePolicy
+
+The resource policy document that will be attached to the namespace.
+
+_Required_: No
+
+_Type_: Map
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-redshiftserverless-namespace/pom.xml
+++ b/aws-redshiftserverless-namespace/pom.xml
@@ -37,7 +37,32 @@
             <artifactId>redshiftserverless</artifactId>
             <version>2.18.31</version>
         </dependency>
-
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/redshift -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>redshift</artifactId>
+            <version>2.21.24</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-core</artifactId>
+            <version>2.21.24</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sdk-core</artifactId>
+            <version>2.21.24</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>2.21.24</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <version>2.21.24</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
@@ -48,7 +73,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->

--- a/aws-redshiftserverless-namespace/resource-role.yaml
+++ b/aws-redshiftserverless-namespace/resource-role.yaml
@@ -46,6 +46,9 @@ Resources:
                 - "redshift-serverless:GetNamespace"
                 - "redshift-serverless:ListNamespaces"
                 - "redshift-serverless:UpdateNamespace"
+                - "redshift:DeleteResourcePolicy"
+                - "redshift:GetResourcePolicy"
+                - "redshift:PutResourcePolicy"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/BaseHandlerStd.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/BaseHandlerStd.java
@@ -9,6 +9,7 @@ import software.amazon.awssdk.services.redshiftserverless.model.Namespace;
 import software.amazon.awssdk.services.redshiftserverless.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.redshiftserverless.model.TooManyTagsException;
 import software.amazon.awssdk.services.redshiftserverless.model.ValidationException;
+import software.amazon.awssdk.services.redshift.RedshiftClient;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -35,6 +36,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
       request,
       callbackContext != null ? callbackContext : new CallbackContext(),
       proxy.newProxy(ClientBuilder::getClient),
+      proxy.newProxy(ClientBuilder::redshiftClient),
       logger
     );
   }
@@ -44,6 +46,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     final ResourceHandlerRequest<ResourceModel> request,
     final CallbackContext callbackContext,
     final ProxyClient<RedshiftServerlessClient> proxyClient,
+    final ProxyClient<RedshiftClient> redshiftProxyClient,
     final Logger logger);
 
   protected boolean isNamespaceActive (final ProxyClient<RedshiftServerlessClient> proxyClient, ResourceModel resourceModel, CallbackContext context) {

--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/CallbackContext.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/CallbackContext.java
@@ -7,7 +7,13 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext {
+    String namespaceArn = null;
     boolean callBackForDelete = false;
+
+    public void setNamespaceArn(String namespaceArn) {this.namespaceArn = namespaceArn; }
+
+    public String getNamespaceArn() { return namespaceArn; }
+
     public void setCallBackForDelete(boolean callBackForDelete) {
         this.callBackForDelete = callBackForDelete;
     }

--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/ClientBuilder.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/ClientBuilder.java
@@ -1,12 +1,21 @@
 package software.amazon.redshiftserverless.namespace;
 
+import software.amazon.awssdk.services.redshift.RedshiftClient;
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
 import software.amazon.cloudformation.LambdaWrapper;
 
+import java.util.function.Supplier;
+
 public class ClientBuilder {
-  public static RedshiftServerlessClient getClient() {
+
+    public static RedshiftServerlessClient getClient() {
     return RedshiftServerlessClient.builder()
             .httpClient(LambdaWrapper.HTTP_CLIENT)
             .build();
   }
+    public static RedshiftClient redshiftClient() {
+        return RedshiftClient.builder()
+                .httpClient(LambdaWrapper.HTTP_CLIENT)
+                .build();
+    }
 }

--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/CreateHandler.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/CreateHandler.java
@@ -1,8 +1,20 @@
 package software.amazon.redshiftserverless.namespace;
 
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.cloudwatch.model.InvalidParameterValueException;
+import software.amazon.awssdk.services.redshift.model.InvalidPolicyException;
+import software.amazon.awssdk.services.redshift.model.PutResourcePolicyRequest;
+import software.amazon.awssdk.services.redshift.model.PutResourcePolicyResponse;
+import software.amazon.awssdk.services.redshift.model.RedshiftException;
+import software.amazon.awssdk.services.redshift.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.redshift.model.UnsupportedOperationException;
 import software.amazon.awssdk.services.redshiftserverless.model.CreateNamespaceRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.CreateNamespaceResponse;
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
+import software.amazon.awssdk.services.redshift.RedshiftClient;
+import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -14,26 +26,40 @@ public class CreateHandler extends BaseHandlerStd {
     private Logger logger;
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
-        final AmazonWebServicesClientProxy proxy,
-        final ResourceHandlerRequest<ResourceModel> request,
-        final CallbackContext callbackContext,
-        final ProxyClient<RedshiftServerlessClient> proxyClient,
-        final Logger logger) {
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final ProxyClient<RedshiftServerlessClient> proxyClient,
+            final ProxyClient<RedshiftClient> redshiftProxyClient,
+            final Logger logger) {
 
         this.logger = logger;
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
-            .then(progress ->
-                proxy.initiate("AWS-RedshiftServerless-Namespace::Create", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
-                        .translateToServiceRequest(Translator::translateToCreateRequest)
-                        .makeServiceCall(this::createNamespace)
-                        .stabilize((_awsRequest, _awsResponse, _client, _model, _context) -> isNamespaceActive(_client, _model, _context))
-                        .handleError(this::createNamespaceErrorHandler)
-                        .progress()
-            )
-            .then(progress ->
-                new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger)
-            );
+                .then(progress -> {
+                    proxy.initiate("AWS-RedshiftServerless-Namespace::Create", proxyClient, progress.getResourceModel(), callbackContext)
+                            .translateToServiceRequest(Translator::translateToCreateRequest)
+                            .makeServiceCall(this::createNamespace)
+                            .stabilize((_awsRequest, _awsResponse, _client, _model, _context) -> isNamespaceActive(_client, _model, _context))
+                            .handleError(this::createNamespaceErrorHandler)
+                            .done((_request, _response, _client, _model, _context) -> {
+                                callbackContext.setNamespaceArn(_response.namespace().namespaceArn());
+                                return ProgressEvent.progress(_model, callbackContext);
+                            });
+                    return progress;
+                })
+                .then(progress -> {
+                    if (progress.getResourceModel().getNamespaceResourcePolicy() != null) {
+                        return proxy.initiate("AWS-Redshift-ResourcePolicy::Put", redshiftProxyClient, progress.getResourceModel(), callbackContext)
+                                .translateToServiceRequest(resourceModelRequest -> Translator.translateToPutResourcePolicy(resourceModelRequest, callbackContext.getNamespaceArn(), logger))
+                                .makeServiceCall(this::putNamespaceResourcePolicy)
+                                .progress();
+                    }
+                    return progress;
+                })
+                .then(progress ->
+                        new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, redshiftProxyClient, logger)
+                );
     }
 
     private CreateNamespaceResponse createNamespace(final CreateNamespaceRequest createNamespaceRequest,
@@ -45,6 +71,26 @@ public class CreateHandler extends BaseHandlerStd {
 
         logger.log(String.format("%s %s successfully created.", ResourceModel.TYPE_NAME, createNamespaceRequest.namespaceName()));
         return createNamespaceResponse;
+    }
+
+    private PutResourcePolicyResponse putNamespaceResourcePolicy(
+            final PutResourcePolicyRequest putRequest,
+            final ProxyClient<RedshiftClient> proxyClient) {
+        PutResourcePolicyResponse putResponse = null;
+
+        try {
+            logger.log(String.format("%s putResourcePolicy.", ResourceModel.TYPE_NAME));
+            putResponse = proxyClient.injectCredentialsAndInvokeV2(putRequest, proxyClient.client()::putResourcePolicy);
+        } catch (ResourceNotFoundException e){
+            throw new CfnNotFoundException(e);
+        } catch (InvalidPolicyException | UnsupportedOperationException | InvalidParameterValueException e) {
+            throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME, e);
+        } catch (SdkClientException | RedshiftException e) {
+            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME, e);
+        }
+
+        logger.log(String.format("%s successfully put resource policy.", putRequest.resourceArn()));
+        return putResponse;
     }
 
     private ProgressEvent<ResourceModel, CallbackContext> createNamespaceErrorHandler(final CreateNamespaceRequest createNamespaceRequest,

--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/DeleteHandler.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/DeleteHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.redshiftserverless.namespace;
 
+import software.amazon.awssdk.services.redshift.RedshiftClient;
 import software.amazon.awssdk.services.redshiftserverless.model.DeleteNamespaceRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.DeleteNamespaceResponse;
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
@@ -17,6 +18,7 @@ public class DeleteHandler extends BaseHandlerStd {
         final ResourceHandlerRequest<ResourceModel> request,
         final CallbackContext callbackContext,
         final ProxyClient<RedshiftServerlessClient> proxyClient,
+        final ProxyClient<RedshiftClient> redshiftProxyClient,
         final Logger logger) {
 
         this.logger = logger;

--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/ReadHandler.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/ReadHandler.java
@@ -1,13 +1,20 @@
 package software.amazon.redshiftserverless.namespace;
 
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.redshift.RedshiftClient;
+import software.amazon.awssdk.services.redshift.model.*;
 import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceResponse;
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
+import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.lang.UnsupportedOperationException;
 
 public class ReadHandler extends BaseHandlerStd {
     private Logger logger;
@@ -17,15 +24,35 @@ public class ReadHandler extends BaseHandlerStd {
         final ResourceHandlerRequest<ResourceModel> request,
         final CallbackContext callbackContext,
         final ProxyClient<RedshiftServerlessClient> proxyClient,
+        final ProxyClient<RedshiftClient> redshiftProxyClient,
         final Logger logger) {
 
         this.logger = logger;
 
-        return proxy.initiate("AWS-RedshiftServerless-Namespace::Read", proxyClient, request.getDesiredResourceState(), callbackContext)
-                .translateToServiceRequest(Translator::translateToReadRequest)
-                .makeServiceCall(this::getNamespace)
-                .handleError(this::getNamespaceErrorHandler)
-                .done(this::constructResourceModelFromResponse);
+        final ResourceModel model = request.getDesiredResourceState();
+
+        return ProgressEvent.progress(model, callbackContext)
+                .then(progress -> {
+                    progress = proxy.initiate("AWS-RedshiftServerless-Namespace::Read", proxyClient, model, callbackContext)
+                            .translateToServiceRequest(Translator::translateToReadRequest)
+                            .makeServiceCall(this::getNamespace)
+                            .handleError(this::getNamespaceErrorHandler)
+                            .done(awsResponse -> {
+                                callbackContext.setNamespaceArn(awsResponse.namespace().namespaceArn());
+                                return ProgressEvent.progress(Translator.translateFromReadResponse(awsResponse), callbackContext);
+                            });
+                    return progress;
+                })
+                .then(progress -> {
+                    progress = proxy.initiate("AWS-Redshift-ResourcePolicy::Get", redshiftProxyClient, progress.getResourceModel(), callbackContext)
+                            .translateToServiceRequest(resourceModelRequest -> Translator.translateToGetResourcePolicy(resourceModelRequest, callbackContext.getNamespaceArn()))
+                            .makeServiceCall(this::getNamespaceResourcePolicy)
+                            .done((_request, _response, _client, _model, _context) -> {
+                                _model.setNamespaceResourcePolicy(Translator.convertStringToJson(_response.resourcePolicy().policy(), logger));
+                                return ProgressEvent.defaultSuccessHandler(_model);
+                            });
+                    return progress;
+                });
     }
 
     private GetNamespaceResponse getNamespace(final GetNamespaceRequest getNamespaceRequest,
@@ -36,6 +63,37 @@ public class ReadHandler extends BaseHandlerStd {
         getNamespaceResponse = proxyClient.injectCredentialsAndInvokeV2(getNamespaceRequest, proxyClient.client()::getNamespace);
         logger.log(String.format("%s %s has successfully been read.", ResourceModel.TYPE_NAME, getNamespaceRequest.namespaceName()));
         return getNamespaceResponse;
+    }
+
+    /**
+     * Gets resource policy for Cluster
+     * @param awsRequest the aws service request to describe a resource
+     * @param proxyClient the aws service client to make the call
+     * @return getResponse resource response
+     */
+    private GetResourcePolicyResponse getNamespaceResourcePolicy(
+            final GetResourcePolicyRequest awsRequest,
+            final ProxyClient<RedshiftClient> proxyClient) {
+        GetResourcePolicyResponse getResponse = null;
+
+        try {
+            logger.log(awsRequest.resourceArn());
+            getResponse = proxyClient.injectCredentialsAndInvokeV2(
+                    awsRequest, proxyClient.client()::getResourcePolicy);
+        } catch (ResourceNotFoundException e){
+            logger.log(String.format("NamespaceResourcePolicy not found for namespace %s", awsRequest.resourceArn()));
+            ResourcePolicy resourcePolicy = ResourcePolicy.builder()
+                    .resourceArn(awsRequest.resourceArn())
+                    .policy("")
+                    .build();
+            return GetResourcePolicyResponse.builder().resourcePolicy(resourcePolicy).build();
+        } catch (InvalidPolicyException | UnsupportedOperationException e) {
+            throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME, e);
+        } catch (SdkClientException | RedshiftException e) {
+            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME, e);
+        }
+        logger.log(String.format("%s  resource policy has successfully been read.", ResourceModel.TYPE_NAME));
+        return getResponse;
     }
 
     private ProgressEvent<ResourceModel, CallbackContext> constructResourceModelFromResponse(

--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/UpdateHandler.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/UpdateHandler.java
@@ -2,9 +2,24 @@ package software.amazon.redshiftserverless.namespace;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.cloudwatch.model.InvalidParameterValueException;
+import software.amazon.awssdk.services.redshift.RedshiftClient;
+import software.amazon.awssdk.services.redshift.model.*;
+import software.amazon.awssdk.services.redshift.model.PutResourcePolicyRequest;
+import software.amazon.awssdk.services.redshift.model.PutResourcePolicyResponse;
+import software.amazon.awssdk.services.redshift.model.UnsupportedOperationException;
+import software.amazon.awssdk.services.redshift.model.DeleteResourcePolicyRequest;
+import software.amazon.awssdk.services.redshift.model.DeleteResourcePolicyResponse;
+import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
+import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceRequest;
+import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceResponse;
+import software.amazon.awssdk.services.redshiftserverless.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.redshiftserverless.model.UpdateNamespaceRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.UpdateNamespaceResponse;
-import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
+import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -21,6 +36,7 @@ public class UpdateHandler extends BaseHandlerStd {
         final ResourceHandlerRequest<ResourceModel> request,
         final CallbackContext callbackContext,
         final ProxyClient<RedshiftServerlessClient> proxyClient,
+        final ProxyClient<RedshiftClient> redshiftProxyClient,
         final Logger logger) {
 
         this.logger = logger;
@@ -66,7 +82,37 @@ public class UpdateHandler extends BaseHandlerStd {
                                 .stabilize((_awsRequest, _awsResponse, _client, _model, _context) -> isNamespaceActive(_client, _model, _context))
                                 .handleError(this::updateNamespaceErrorHandler)
                                 .progress())
-                .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
+                .then(progress -> {
+                    progress = proxy.initiate("AWS-RedshiftServerless-Namespace::Read", proxyClient, updateRequestModel, callbackContext)
+                            .translateToServiceRequest(Translator::translateToReadRequest)
+                            .makeServiceCall(this::getNamespace)
+                            .handleError(this::getNamespaceErrorHandler)
+                            .done(awsResponse -> {
+                                callbackContext.setNamespaceArn(awsResponse.namespace().namespaceArn());
+                                return ProgressEvent.progress(Translator.translateFromReadResponse(awsResponse), callbackContext);
+                            });
+                    return progress;
+                })
+                .then(progress -> {
+                    if (callbackContext.getNamespaceArn() != null && currentModel.getNamespaceResourcePolicy() != null)  {
+                        if (currentModel.getNamespaceResourcePolicy().isEmpty()) {
+                            if (request.getPreviousResourceState().getNamespaceResourcePolicy() != null) {
+                                return proxy.initiate("AWS-Redshift-ResourcePolicy::Delete", redshiftProxyClient, updateRequestModel, callbackContext)
+                                        .translateToServiceRequest(resourceModelRequest -> Translator.translateToDeleteResourcePolicyRequest(resourceModelRequest, callbackContext.getNamespaceArn()))
+                                        .makeServiceCall(this::deleteNamespaceResourcePolicy)
+                                        .progress();
+                            }
+                        }
+                        else {
+                            return proxy.initiate("AWS-Redshift-ResourcePolicy::Update", redshiftProxyClient, updateRequestModel, callbackContext)
+                                    .translateToServiceRequest(resourceModel -> Translator.translateToPutResourcePolicy(resourceModel, callbackContext.getNamespaceArn(), logger))
+                                    .makeServiceCall(this::putNamespaceResourcePolicy)
+                                    .progress();
+                        }
+                    }
+                    return progress;
+                })
+                .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, redshiftProxyClient, logger));
     }
 
     private UpdateNamespaceResponse updateNamespace(final UpdateNamespaceRequest updateNamespaceRequest,
@@ -80,11 +126,67 @@ public class UpdateHandler extends BaseHandlerStd {
         return updateNamespaceResponse;
     }
 
+    private GetNamespaceResponse getNamespace(final GetNamespaceRequest getNamespaceRequest,
+                                              final ProxyClient<RedshiftServerlessClient> proxyClient) {
+        GetNamespaceResponse getNamespaceResponse = null;
+
+        logger.log(String.format("%s %s getNamespaces.", ResourceModel.TYPE_NAME, getNamespaceRequest.namespaceName()));
+        getNamespaceResponse = proxyClient.injectCredentialsAndInvokeV2(getNamespaceRequest, proxyClient.client()::getNamespace);
+        logger.log(String.format("%s %s has successfully been read.", ResourceModel.TYPE_NAME, getNamespaceRequest.namespaceName()));
+        return getNamespaceResponse;
+    }
+
+    private PutResourcePolicyResponse putNamespaceResourcePolicy(
+            final PutResourcePolicyRequest putRequest,
+            final ProxyClient<RedshiftClient> proxyClient) {
+        PutResourcePolicyResponse putResponse = null;
+
+        try {
+            putResponse = proxyClient.injectCredentialsAndInvokeV2(putRequest, proxyClient.client()::putResourcePolicy);
+        } catch (ResourceNotFoundException e){
+            throw new CfnNotFoundException(e);
+        } catch (InvalidPolicyException | UnsupportedOperationException | InvalidParameterValueException e) {
+            throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME, e);
+        } catch (SdkClientException | RedshiftException  e) {
+            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME, e);
+        }
+
+        logger.log(String.format("%s successfully put resource policy.", ResourceModel.TYPE_NAME));
+        return putResponse;
+    }
+
+    private DeleteResourcePolicyResponse deleteNamespaceResourcePolicy(
+            final DeleteResourcePolicyRequest deleteRequest,
+            final ProxyClient<RedshiftClient> proxyClient) {
+        DeleteResourcePolicyResponse deleteResponse = null;
+
+        try{
+            deleteResponse = proxyClient.injectCredentialsAndInvokeV2(deleteRequest, proxyClient.client()::deleteResourcePolicy);
+        } catch (ResourceNotFoundException e){
+            throw new CfnNotFoundException(e);
+        } catch ( UnsupportedOperationException e) {
+            throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME, e);
+        } catch (SdkClientException | RedshiftException e) {
+            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME, e);
+        }
+
+        logger.log(String.format("%s successfully deleted resource policy.", ResourceModel.TYPE_NAME));
+        return deleteResponse;
+    }
+
     private ProgressEvent<ResourceModel, CallbackContext> updateNamespaceErrorHandler(final UpdateNamespaceRequest updateNamespaceRequest,
                                                                                       final Exception exception,
                                                                                       final ProxyClient<RedshiftServerlessClient> client,
                                                                                       final ResourceModel model,
                                                                                       final CallbackContext context) {
+        return errorHandler(exception);
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> getNamespaceErrorHandler(final GetNamespaceRequest getNamespaceRequest,
+                                                                                   final Exception exception,
+                                                                                   final ProxyClient<RedshiftServerlessClient> client,
+                                                                                   final ResourceModel model,
+                                                                                   final CallbackContext context) {
         return errorHandler(exception);
     }
 

--- a/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/AbstractTestBase.java
+++ b/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/AbstractTestBase.java
@@ -13,6 +13,9 @@ import software.amazon.awssdk.awscore.AwsResponse;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.awssdk.services.redshift.model.GetResourcePolicyResponse;
+import software.amazon.awssdk.services.redshift.model.PutResourcePolicyResponse;
+import software.amazon.awssdk.services.redshift.model.ResourcePolicy;
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
 import software.amazon.awssdk.services.redshiftserverless.model.CreateNamespaceResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.DeleteNamespaceResponse;
@@ -43,6 +46,10 @@ public class AbstractTestBase {
   private static final String FINAL_SNAPSHOT_NAME;
   private static final int FINAL_SNAPSHOT_RETENTION_PERIOD;
   protected static final String AWS_REGION = "us-east-1";
+  protected static final String NAMESPACE_RESOURCE_POLICY_DOCUMENT;
+  protected static final String NAMESPACE_RESOURCE_POLICY_DOCUMENT_EMPTY;
+  protected static final ResourcePolicy NAMESPACE_RESOURCE_POLICY;
+  protected static final ResourcePolicy NAMESPACE_RESOURCE_POLICY_EMPTY;
 
   static {
     MOCK_CREDENTIALS = new Credentials("accessKey", "secretKey", "token");
@@ -62,6 +69,9 @@ public class AbstractTestBase {
     CREATION_DATE = Instant.parse("9999-01-01T00:00:00Z");
     FINAL_SNAPSHOT_NAME = "testFinalSnapshot";
     FINAL_SNAPSHOT_RETENTION_PERIOD = 1;
+    NAMESPACE_RESOURCE_POLICY_DOCUMENT = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Resource\": \"*\",\"Action\":\"test:test\"}]}";
+    NAMESPACE_RESOURCE_POLICY_DOCUMENT_EMPTY = "{}";
+
     NAMESPACE = software.amazon.awssdk.services.redshiftserverless.model.Namespace.builder()
             .namespaceName(NAMESPACE_NAME)
             .namespaceArn("DummyNamespaceArn")
@@ -75,11 +85,21 @@ public class AbstractTestBase {
             .status(STATUS)
             .creationDate(CREATION_DATE)
             .build();
+
+    NAMESPACE_RESOURCE_POLICY = ResourcePolicy.builder()
+            .resourceArn(NAMESPACE.namespaceArn())
+            .policy(NAMESPACE_RESOURCE_POLICY_DOCUMENT)
+            .build();
+
+    NAMESPACE_RESOURCE_POLICY_EMPTY = ResourcePolicy.builder()
+            .resourceArn(NAMESPACE.namespaceArn())
+            .policy(null)
+            .build();
   }
-  static ProxyClient<RedshiftServerlessClient> MOCK_PROXY(
+  static <T> ProxyClient<T> MOCK_PROXY(
     final AmazonWebServicesClientProxy proxy,
-    final RedshiftServerlessClient sdkClient) {
-    return new ProxyClient<RedshiftServerlessClient>() {
+    final T sdkClient) {
+    return new ProxyClient<T>() {
       @Override
       public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseT
       injectCredentialsAndInvokeV2(RequestT request, Function<RequestT, ResponseT> requestFunction) {
@@ -113,7 +133,7 @@ public class AbstractTestBase {
       }
 
       @Override
-      public RedshiftServerlessClient client() {
+      public T client() {
         return sdkClient;
       }
     };
@@ -242,6 +262,24 @@ public class AbstractTestBase {
   public static UpdateNamespaceResponse getUpdateResponseSdk() {
     return UpdateNamespaceResponse.builder()
             .namespace(NAMESPACE)
+            .build();
+  }
+
+  public static PutResourcePolicyResponse putResourcePolicyResponseSdk() {
+    return PutResourcePolicyResponse.builder()
+            .resourcePolicy(NAMESPACE_RESOURCE_POLICY)
+            .build();
+  }
+
+  public static GetResourcePolicyResponse getResourcePolicyResponseSdk() {
+    return GetResourcePolicyResponse.builder()
+            .resourcePolicy(NAMESPACE_RESOURCE_POLICY)
+            .build();
+  }
+
+  public static GetResourcePolicyResponse getEmptyResourcePolicyResponseSdk() {
+    return GetResourcePolicyResponse.builder()
+            .resourcePolicy(NAMESPACE_RESOURCE_POLICY_EMPTY)
             .build();
   }
 }

--- a/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/CreateHandlerTest.java
+++ b/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/CreateHandlerTest.java
@@ -2,6 +2,11 @@ package software.amazon.redshiftserverless.namespace;
 
 import java.time.Duration;
 
+import software.amazon.awssdk.services.redshift.RedshiftClient;
+import software.amazon.awssdk.services.redshift.model.CreateClusterRequest;
+import software.amazon.awssdk.services.redshift.model.DescribeClustersRequest;
+import software.amazon.awssdk.services.redshift.model.GetResourcePolicyRequest;
+import software.amazon.awssdk.services.redshift.model.PutResourcePolicyRequest;
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
 import software.amazon.awssdk.services.redshiftserverless.model.CreateNamespaceRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceRequest;
@@ -18,12 +23,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends AbstractTestBase {
@@ -37,11 +38,20 @@ public class CreateHandlerTest extends AbstractTestBase {
     @Mock
     RedshiftServerlessClient sdkClient;
 
+    @Mock
+    private ProxyClient<RedshiftClient> redshiftProxyClient;
+
+    @Mock
+    RedshiftClient redshiftSdkClient;
+
     @BeforeEach
     public void setup() {
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         sdkClient = mock(RedshiftServerlessClient.class);
         proxyClient = MOCK_PROXY(proxy, sdkClient);
+
+        redshiftSdkClient = mock(RedshiftClient.class);
+        redshiftProxyClient = MOCK_PROXY(proxy, redshiftSdkClient);
     }
 
     @AfterEach
@@ -62,8 +72,38 @@ public class CreateHandlerTest extends AbstractTestBase {
             .build();
         when(proxyClient.client().createNamespace(any(CreateNamespaceRequest.class))).thenReturn(getCreateResponseSdk());
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
+        when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(responseResourceModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void testPutNamespaceResourcePolicy() {
+        final CreateHandler handler = new CreateHandler();
+
+        final ResourceModel requestResourceModel = getCreateRequestResourceModel();
+        final ResourceModel responseResourceModel = getCreateResponseResourceMode();
+
+        requestResourceModel.setNamespaceResourcePolicy(Translator.convertStringToJson(NAMESPACE_RESOURCE_POLICY_DOCUMENT, logger));
+        responseResourceModel.setNamespaceResourcePolicy(Translator.convertStringToJson(NAMESPACE_RESOURCE_POLICY_DOCUMENT, logger));
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(requestResourceModel)
+                .build();
+        when(proxyClient.client().createNamespace(any(CreateNamespaceRequest.class))).thenReturn(getCreateResponseSdk());
+        when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
+        when(redshiftProxyClient.client().putResourcePolicy(any(PutResourcePolicyRequest.class))).thenReturn(putResourcePolicyResponseSdk());
+        when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getResourcePolicyResponseSdk());
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);


### PR DESCRIPTION
Integrating Redshift Resource Policy with Redshift Serverless Namespace.

1. Once the Namespace is created and in active stage, Resource Policy will be attached to Namespace if the resource policy is included with templates while creating the namespace.
2. Resource policy can be modified or deleted using Cfn Update handler.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
