### PR TITLE
Cloudformation support for Secrets Manager Integration

### DIFF
--- a/aws-redshiftserverless-namespace/aws-redshiftserverless-namespace.json
+++ b/aws-redshiftserverless-namespace/aws-redshiftserverless-namespace.json
@@ -62,6 +62,12 @@
                 },
                 "CreationDate": {
                     "type": "string"
+                },
+                "AdminPasswordSecretArn": {
+                    "type": "string"
+                },
+                "AdminPasswordSecretKmsKeyId": {
+                    "type": "string"
                 }
             },
             "additionalProperties": false
@@ -96,8 +102,12 @@
         }
     },
     "properties": {
+        "AdminPasswordSecretKmsKeyId": {
+            "description": "The ID of the AWS Key Management Service (KMS) key used to encrypt and store the namespace's admin credentials secret. You can only use this parameter if manageAdminPassword is true.",
+            "type": "string"
+        },
         "AdminUserPassword": {
-            "description": "The password associated with the admin user for the namespace that is being created. Password must be at least 8 characters in length, should be any printable ASCII character. Must contain at least one lowercase letter, one uppercase letter and one decimal digit.",
+            "description": "The password associated with the admin user for the namespace that is being created. Password must be at least 8 characters in length, should be any printable ASCII character. Must contain at least one lowercase letter, one uppercase letter and one decimal digit. You can't use adminUserPassword if manageAdminPassword is true.",
             "type": "string",
             "maxLength": 64,
             "minLength": 8,
@@ -141,6 +151,10 @@
             },
             "maxItems": 16,
             "minItems": 0
+        },
+        "ManageAdminPassword": {
+            "description": "If true, Amazon Redshift uses AWS Secrets Manager to manage the namespace's admin credentials. You can't use adminUserPassword if manageAdminPassword is true. If manageAdminPassword is false or not set, Amazon Redshift uses adminUserPassword for the admin user account's password.",
+            "type": "boolean"
         },
         "Namespace": {
             "$ref": "#/definitions/Namespace"
@@ -195,7 +209,9 @@
         "/properties/Namespace/IamRoles",
         "/properties/Namespace/LogExports",
         "/properties/Namespace/Status",
-        "/properties/Namespace/CreationDate"
+        "/properties/Namespace/CreationDate",
+        "/properties/Namespace/AdminPasswordSecretArn",
+        "/properties/Namespace/AdminPasswordSecretKmsKeyId"
     ],
     "writeOnlyProperties": [
         "/properties/AdminUserPassword",
@@ -203,7 +219,8 @@
         "/properties/FinalSnapshotRetentionPeriod",
         "/properties/Tags",
         "/properties/Tags/*/Key",
-        "/properties/Tags/*/Value"
+        "/properties/Tags/*/Value",
+        "/properties/ManageAdminPassword"
     ],
     "createOnlyProperties": [
         "/properties/NamespaceName",

--- a/aws-redshiftserverless-namespace/docs/README.md
+++ b/aws-redshiftserverless-namespace/docs/README.md
@@ -12,6 +12,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 {
     "Type" : "AWS::RedshiftServerless::Namespace",
     "Properties" : {
+        "<a href="#adminpasswordsecretkmskeyid" title="AdminPasswordSecretKmsKeyId">AdminPasswordSecretKmsKeyId</a>" : <i>String</i>,
         "<a href="#adminuserpassword" title="AdminUserPassword">AdminUserPassword</a>" : <i>String</i>,
         "<a href="#adminusername" title="AdminUsername">AdminUsername</a>" : <i>String</i>,
         "<a href="#dbname" title="DbName">DbName</a>" : <i>String</i>,
@@ -19,6 +20,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#iamroles" title="IamRoles">IamRoles</a>" : <i>[ String, ... ]</i>,
         "<a href="#kmskeyid" title="KmsKeyId">KmsKeyId</a>" : <i>String</i>,
         "<a href="#logexports" title="LogExports">LogExports</a>" : <i>[ String, ... ]</i>,
+        "<a href="#manageadminpassword" title="ManageAdminPassword">ManageAdminPassword</a>" : <i>Boolean</i>,
         "<a href="#namespacename" title="NamespaceName">NamespaceName</a>" : <i>String</i>,
         "<a href="#tags" title="Tags">Tags</a>" : <i>[ <a href="tag.md">Tag</a>, ... ]</i>,
         "<a href="#finalsnapshotname" title="FinalSnapshotName">FinalSnapshotName</a>" : <i>String</i>,
@@ -33,6 +35,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 Type: AWS::RedshiftServerless::Namespace
 Properties:
+    <a href="#adminpasswordsecretkmskeyid" title="AdminPasswordSecretKmsKeyId">AdminPasswordSecretKmsKeyId</a>: <i>String</i>
     <a href="#adminuserpassword" title="AdminUserPassword">AdminUserPassword</a>: <i>String</i>
     <a href="#adminusername" title="AdminUsername">AdminUsername</a>: <i>String</i>
     <a href="#dbname" title="DbName">DbName</a>: <i>String</i>
@@ -42,6 +45,7 @@ Properties:
     <a href="#kmskeyid" title="KmsKeyId">KmsKeyId</a>: <i>String</i>
     <a href="#logexports" title="LogExports">LogExports</a>: <i>
       - String</i>
+    <a href="#manageadminpassword" title="ManageAdminPassword">ManageAdminPassword</a>: <i>Boolean</i>
     <a href="#namespacename" title="NamespaceName">NamespaceName</a>: <i>String</i>
     <a href="#tags" title="Tags">Tags</a>: <i>
       - <a href="tag.md">Tag</a></i>
@@ -52,9 +56,19 @@ Properties:
 
 ## Properties
 
+#### AdminPasswordSecretKmsKeyId
+
+The ID of the AWS Key Management Service (KMS) key used to encrypt and store the namespace's admin credentials secret. You can only use this parameter if manageAdminPassword is true.
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
 #### AdminUserPassword
 
-The password associated with the admin user for the namespace that is being created. Password must be at least 8 characters in length, should be any printable ASCII character. Must contain at least one lowercase letter, one uppercase letter and one decimal digit.
+The password associated with the admin user for the namespace that is being created. Password must be at least 8 characters in length, should be any printable ASCII character. Must contain at least one lowercase letter, one uppercase letter and one decimal digit. You can't use adminUserPassword if manageAdminPassword is true.
 
 _Required_: No
 
@@ -131,6 +145,16 @@ The collection of log types to be exported provided by the customer. Should only
 _Required_: No
 
 _Type_: List of String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### ManageAdminPassword
+
+If true, Amazon Redshift uses AWS Secrets Manager to manage the namespace's admin credentials. You can't use adminUserPassword if manageAdminPassword is true. If manageAdminPassword is false or not set, Amazon Redshift uses adminUserPassword for the admin user account's password.
+
+_Required_: No
+
+_Type_: Boolean
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -253,3 +277,11 @@ Returns the <code>Status</code> value.
 #### CreationDate
 
 Returns the <code>CreationDate</code> value.
+
+#### AdminPasswordSecretArn
+
+Returns the <code>AdminPasswordSecretArn</code> value.
+
+#### AdminPasswordSecretKmsKeyId
+
+Returns the <code>AdminPasswordSecretKmsKeyId</code> value.

--- a/aws-redshiftserverless-namespace/pom.xml
+++ b/aws-redshiftserverless-namespace/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>redshiftserverless</artifactId>
-            <version>2.18.31</version>
+            <version>2.21.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/redshift -->
         <dependency>

--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/Translator.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/Translator.java
@@ -1,5 +1,6 @@
 package software.amazon.redshiftserverless.namespace;
 
+import com.amazonaws.util.StringUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -7,7 +8,6 @@ import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.services.redshift.model.DeleteResourcePolicyRequest;
 import software.amazon.awssdk.services.redshift.model.GetResourcePolicyRequest;
 import software.amazon.awssdk.services.redshift.model.PutResourcePolicyRequest;
-import software.amazon.awssdk.services.redshift.model.GetResourcePolicyResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.CreateNamespaceRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.DeleteNamespaceRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceRequest;
@@ -49,6 +49,8 @@ public class Translator {
             .iamRoles(model.getIamRoles())
             .logExportsWithStrings(model.getLogExports())
             .tags(translateTagsToSdk(model.getTags()))
+            .manageAdminPassword(model.getManageAdminPassword())
+            .adminPasswordSecretKmsKeyId(model.getAdminPasswordSecretKmsKeyId())
             .build();
   }
 
@@ -88,6 +90,8 @@ public class Translator {
             .logExports(awsResponse.namespace().logExportsAsStrings())
             .namespaceName(awsResponse.namespace().namespaceName())
             .namespace(translateToModelNamespace(awsResponse.namespace()))
+            .manageAdminPassword(StringUtils.isNullOrEmpty(awsResponse.namespace().adminPasswordSecretArn()) ? null : true)
+            .adminPasswordSecretKmsKeyId(awsResponse.namespace().adminPasswordSecretKmsKeyId())
             .build();
   }
 
@@ -121,6 +125,8 @@ public class Translator {
             //TODO: we only support updating db-name after GA
 //            .dbName(model.getDbName())
             .defaultIamRoleArn(model.getDefaultIamRoleArn())
+            .manageAdminPassword(model.getManageAdminPassword())
+            .adminPasswordSecretKmsKeyId(model.getAdminPasswordSecretKmsKeyId())
             .build();
   }
 
@@ -194,6 +200,8 @@ public class Translator {
             .logExports(namespace.logExportsAsStrings())
             .status(namespace.statusAsString())
             .creationDate(namespace.creationDate() == null ? null : namespace.creationDate().toString())
+            .adminPasswordSecretArn(namespace.adminPasswordSecretArn())
+            .adminPasswordSecretKmsKeyId(namespace.adminPasswordSecretKmsKeyId())
             .build();
   }
 

--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/UpdateHandler.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/UpdateHandler.java
@@ -1,16 +1,13 @@
 package software.amazon.redshiftserverless.namespace;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.cloudwatch.model.InvalidParameterValueException;
 import software.amazon.awssdk.services.redshift.RedshiftClient;
 import software.amazon.awssdk.services.redshift.model.*;
-import software.amazon.awssdk.services.redshift.model.PutResourcePolicyRequest;
-import software.amazon.awssdk.services.redshift.model.PutResourcePolicyResponse;
 import software.amazon.awssdk.services.redshift.model.UnsupportedOperationException;
-import software.amazon.awssdk.services.redshift.model.DeleteResourcePolicyRequest;
-import software.amazon.awssdk.services.redshift.model.DeleteResourcePolicyResponse;
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
 import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceResponse;
@@ -54,6 +51,8 @@ public class UpdateHandler extends BaseHandlerStd {
                 .defaultIamRoleArn(StringUtils.equals(prevModel.getDefaultIamRoleArn(), currentModel.getDefaultIamRoleArn()) ? null : currentModel.getDefaultIamRoleArn())
                 .iamRoles(compareListParamsEqualOrNot(prevModel.getIamRoles(), currentModel.getIamRoles()) ? null : currentModel.getIamRoles())
                 .logExports(compareListParamsEqualOrNot(prevModel.getLogExports(), currentModel.getLogExports()) ? null : currentModel.getLogExports())
+                .manageAdminPassword((prevModel.getManageAdminPassword() == currentModel.getManageAdminPassword()) ? null : currentModel.getManageAdminPassword())
+                .adminPasswordSecretKmsKeyId(StringUtils.equals(prevModel.getAdminPasswordSecretKmsKeyId(), currentModel.getAdminPasswordSecretKmsKeyId()) ? null : currentModel.getAdminPasswordSecretKmsKeyId())
                 .build();
 
         // To update the adminUserPassword or adminUserName, we need to specify both username and password in update request
@@ -69,6 +68,14 @@ public class UpdateHandler extends BaseHandlerStd {
             tempUpdateRequestModel = tempUpdateRequestModel.toBuilder()
                     .defaultIamRoleArn(currentModel.getDefaultIamRoleArn())
                     .iamRoles(currentModel.getIamRoles())
+                    .build();
+        }
+
+        // To update the adminPasswordSecretKmsKeyId, we need to specify both manageAdminPassword and adminPasswordSecretKmsKeyId in update request
+        if (!StringUtils.equals(prevModel.getAdminPasswordSecretKmsKeyId(), currentModel.getAdminPasswordSecretKmsKeyId())) {
+            tempUpdateRequestModel = tempUpdateRequestModel.toBuilder()
+                    .manageAdminPassword(currentModel.getManageAdminPassword())
+                    .adminPasswordSecretKmsKeyId(currentModel.getAdminPasswordSecretKmsKeyId())
                     .build();
         }
 

--- a/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/AbstractTestBase.java
+++ b/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/AbstractTestBase.java
@@ -43,6 +43,7 @@ public class AbstractTestBase {
   private static final String STATUS;
   private static final Instant CREATION_DATE;
   private static final software.amazon.awssdk.services.redshiftserverless.model.Namespace NAMESPACE;
+  private static final software.amazon.awssdk.services.redshiftserverless.model.Namespace NAMESPACE_WITH_MANAGED_ADMIN_PASSWORD;
   private static final String FINAL_SNAPSHOT_NAME;
   private static final int FINAL_SNAPSHOT_RETENTION_PERIOD;
   protected static final String AWS_REGION = "us-east-1";
@@ -50,6 +51,8 @@ public class AbstractTestBase {
   protected static final String NAMESPACE_RESOURCE_POLICY_DOCUMENT_EMPTY;
   protected static final ResourcePolicy NAMESPACE_RESOURCE_POLICY;
   protected static final ResourcePolicy NAMESPACE_RESOURCE_POLICY_EMPTY;
+  protected static final String SECRET_ARN;
+  protected static final String SECRET_KMS_KEY_ID;
 
   static {
     MOCK_CREDENTIALS = new Credentials("accessKey", "secretKey", "token");
@@ -71,6 +74,8 @@ public class AbstractTestBase {
     FINAL_SNAPSHOT_RETENTION_PERIOD = 1;
     NAMESPACE_RESOURCE_POLICY_DOCUMENT = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Resource\": \"*\",\"Action\":\"test:test\"}]}";
     NAMESPACE_RESOURCE_POLICY_DOCUMENT_EMPTY = "{}";
+    SECRET_ARN = "DummyClusterSecretArn";
+    SECRET_KMS_KEY_ID = "DummySecretKmsKeyId";
 
     NAMESPACE = software.amazon.awssdk.services.redshiftserverless.model.Namespace.builder()
             .namespaceName(NAMESPACE_NAME)
@@ -85,6 +90,11 @@ public class AbstractTestBase {
             .status(STATUS)
             .creationDate(CREATION_DATE)
             .build();
+
+    NAMESPACE_WITH_MANAGED_ADMIN_PASSWORD = NAMESPACE.toBuilder()
+                                        .adminPasswordSecretArn(SECRET_ARN)
+                                        .adminPasswordSecretKmsKeyId(SECRET_KMS_KEY_ID)
+                                        .build();
 
     NAMESPACE_RESOURCE_POLICY = ResourcePolicy.builder()
             .resourceArn(NAMESPACE.namespaceArn())
@@ -153,7 +163,15 @@ public class AbstractTestBase {
               .build();
   }
 
-  public static ResourceModel getCreateResponseResourceMode() {
+  public static ResourceModel getCreateRequestResourceModelWithManagedAdminPassword() {
+      return getCreateRequestResourceModel().toBuilder()
+              .adminUserPassword(null)
+              .manageAdminPassword(true)
+              .adminPasswordSecretKmsKeyId(SECRET_KMS_KEY_ID)
+              .build();
+  }
+
+  public static ResourceModel getCreateResponseResourceModel() {
     return ResourceModel.builder()
             .adminUsername(ADMIN_USERNAME)
             .dbName(DB_NAME)
@@ -165,6 +183,15 @@ public class AbstractTestBase {
             .namespace(translateToModelNamespace(NAMESPACE))
             .build();
   }
+
+  public static ResourceModel getCreateResponseResourceModelWithManagedAdminPassword() {
+    return getCreateResponseResourceModel().toBuilder()
+            .adminPasswordSecretKmsKeyId(SECRET_KMS_KEY_ID)
+            .manageAdminPassword(true)
+            .namespace(translateToModelNamespace(NAMESPACE_WITH_MANAGED_ADMIN_PASSWORD))
+            .build();
+  }
+
 
   private static Namespace translateToModelNamespace(
           software.amazon.awssdk.services.redshiftserverless.model.Namespace namespace) {
@@ -180,6 +207,8 @@ public class AbstractTestBase {
             .logExports(namespace.logExportsAsStrings())
             .status(namespace.statusAsString())
             .creationDate(namespace.creationDate().toString())
+            .adminPasswordSecretArn(namespace.adminPasswordSecretArn())
+            .adminPasswordSecretKmsKeyId(namespace.adminPasswordSecretKmsKeyId())
             .build();
   }
 
@@ -189,9 +218,21 @@ public class AbstractTestBase {
             .build();
   }
 
+  public static CreateNamespaceResponse getCreateResponseSdkForManagedAdminPasswords() {
+    return CreateNamespaceResponse.builder()
+            .namespace(NAMESPACE_WITH_MANAGED_ADMIN_PASSWORD)
+            .build();
+  }
+
   public static GetNamespaceResponse getNamespaceResponseSdk() {
     return GetNamespaceResponse.builder()
             .namespace(NAMESPACE)
+            .build();
+  }
+
+  public static GetNamespaceResponse getNamespaceResponseSdkForManagedAdminPasswords() {
+    return GetNamespaceResponse.builder()
+            .namespace(NAMESPACE_WITH_MANAGED_ADMIN_PASSWORD)
             .build();
   }
 
@@ -255,13 +296,31 @@ public class AbstractTestBase {
             .build();
   }
 
+  public static ResourceModel getUpdateRequestResourceModelWithManagedAdminPassword() {
+    return  getUpdateRequestResourceModel().toBuilder()
+            .adminUserPassword(null)
+            .manageAdminPassword(true)
+            .adminPasswordSecretKmsKeyId(SECRET_KMS_KEY_ID)
+            .build();
+  }
+
   public static ResourceModel getUpdateResponseResourceModel() {
-    return getCreateResponseResourceMode();
+    return getCreateResponseResourceModel();
+  }
+
+  public static ResourceModel getUpdateResponseResourceModelWithManagedAdminPassword() {
+    return getCreateResponseResourceModelWithManagedAdminPassword();
   }
 
   public static UpdateNamespaceResponse getUpdateResponseSdk() {
     return UpdateNamespaceResponse.builder()
             .namespace(NAMESPACE)
+            .build();
+  }
+
+  public static UpdateNamespaceResponse getUpdateResponseSdkForManagedAdminPasswords() {
+    return UpdateNamespaceResponse.builder()
+            .namespace(NAMESPACE_WITH_MANAGED_ADMIN_PASSWORD)
             .build();
   }
 


### PR DESCRIPTION
The changes provide Cloudformation support for Secrets Manager integration with Redshift Serverless. With this new feature, customers can opt in to store their namespace's admin credentials in a service linked secret in Secrets Manager. It allows us to create/modify Redshift Serverless namespaces with Secrets Manager support using the Cloudformation template. The changes in this request allow us to use create-namespace and update-namespace APIs for Redshift Serverless namespaces when opting in to this feature.

We are adding a new boolean parameter "ManageAdminPassword" to allow customers to opt in to this feature and another parameter "AdminPasswordSecretKmsKeyId" allows customers to specify the key ID of the KMS key in the customer account which will be used to encrypt the namespace's secret. These parameters can be used while setting CreateNamespaceRequest and UpdateNamespaceRequest. The response of these requests will return the "AdminPasswordSecretArn" when the namespace is opted in to this feature.