### PR TITLE
No-Op method for handling GetResourcePolicy exceptions.

### DIFF
--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/Translator.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/Translator.java
@@ -259,7 +259,11 @@ public class Translator {
     };
     try {
       if (policy != null) {
-        json = mapper.readValue(URLDecoder.decode(policy, StandardCharsets.UTF_8.toString()), typeRef);
+        if (policy.isEmpty()) {
+          logger.log("Empty NamespaceResourcePolicy");
+        } else {
+          json = mapper.readValue(URLDecoder.decode(policy, StandardCharsets.UTF_8.toString()), typeRef);
+        }
       }
     } catch (IOException e) {
       logger.log("Error parsing Policy String to Json");

--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/UpdateHandler.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/UpdateHandler.java
@@ -90,7 +90,7 @@ public class UpdateHandler extends BaseHandlerStd {
                                 .handleError(this::updateNamespaceErrorHandler)
                                 .progress())
                 .then(progress -> {
-                    progress = proxy.initiate("AWS-RedshiftServerless-Namespace::Read", proxyClient, updateRequestModel, callbackContext)
+                    progress = proxy.initiate("AWS-RedshiftServerless-Namespace::ReadOnly", proxyClient, updateRequestModel, callbackContext)
                             .translateToServiceRequest(Translator::translateToReadRequest)
                             .makeServiceCall(this::getNamespace)
                             .handleError(this::getNamespaceErrorHandler)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Read Handler - NoOp method for handling GetresourcePolicy Exceptions - this method will assign empty value to NamespaceResourcePolicy if there are permission issues that restrict accessing GetResourcePolicy API. Also, empty value is assigned if NamespaceResourcePolicy is not found on the Namespace. Assigning empty value will suppress NamespaceResourcePolicy property in CreateCluster Cfn response.
2. Translator - Update logger to handle empty NamespaceResourcePolicy.
3. Update Handler - Rename CallGraph name to avoid conflicts with Read Handler CallGraph name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
