### PR TITLE
Modified Translater to format iam roles for backward compatibility

### DIFF
--- a/aws-redshiftserverless-namespace/.rpdk-config
+++ b/aws-redshiftserverless-namespace/.rpdk-config
@@ -21,5 +21,7 @@
         "codegen_template_path": "guided_aws",
         "protocolVersion": "2.0.0"
     },
-    "executableEntrypoint": "software.amazon.redshiftserverless.namespace.HandlerWrapperExecutable"
+    "logProcessorEnabled": "true",
+    "executableEntrypoint": "software.amazon.redshiftserverless.namespace.HandlerWrapperExecutable",
+    "contractSettings": {}
 }

--- a/aws-redshiftserverless-namespace/aws-redshiftserverless-namespace.json
+++ b/aws-redshiftserverless-namespace/aws-redshiftserverless-namespace.json
@@ -214,9 +214,7 @@
         "/properties/Namespace/IamRoles",
         "/properties/Namespace/LogExports",
         "/properties/Namespace/Status",
-        "/properties/Namespace/CreationDate",
-        "/properties/Namespace/AdminPasswordSecretArn",
-        "/properties/Namespace/AdminPasswordSecretKmsKeyId"
+        "/properties/Namespace/CreationDate"
     ],
     "writeOnlyProperties": [
         "/properties/AdminUserPassword",
@@ -246,13 +244,20 @@
                 "kms:Encrypt",
                 "kms:Decrypt",
                 "kms:DescribeKey",
+                "kms:GenerateDataKeyPair",
+                "kms:GenerateDataKey",
                 "kms:CreateGrant",
                 "kms:ListGrants",
                 "kms:RevokeGrant",
+                "kms:RetireGrant",
                 "redshift-serverless:CreateNamespace",
                 "redshift-serverless:GetNamespace",
                 "redshift:GetResourcePolicy",
-                "redshift:PutResourcePolicy"
+                "redshift:PutResourcePolicy",
+                "secretsmanager:CreateSecret",
+                "secretsmanager:TagResource",
+                "secretsmanager:RotateSecret",
+                "secretsmanager:DescribeSecret"
             ]
         },
         "read": {
@@ -275,18 +280,31 @@
                 "kms:CreateGrant",
                 "kms:ListGrants",
                 "kms:RevokeGrant",
+                "kms:RetireGrant",
+                "kms:GenerateDataKeyPair",
+                "kms:GenerateDataKey",
                 "redshift-serverless:UpdateNamespace",
                 "redshift-serverless:GetNamespace",
                 "redshift:GetResourcePolicy",
                 "redshift:PutResourcePolicy",
-                "redshift:DeleteResourcePolicy"
+                "redshift:DeleteResourcePolicy",
+                "secretsmanager:CreateSecret",
+                "secretsmanager:TagResource",
+                "secretsmanager:RotateSecret",
+                "secretsmanager:DescribeSecret",
+                "secretsmanager:UpdateSecret",
+                "secretsmanager:DeleteSecret"
             ]
         },
         "delete": {
             "permissions": [
                 "iam:PassRole",
                 "redshift-serverless:DeleteNamespace",
-                "redshift-serverless:GetNamespace"
+                "redshift-serverless:GetNamespace",
+                "kms:RetireGrant",
+                "secretsmanager:DescribeSecret",
+                "secretsmanager:DeleteSecret",
+                "redshift:DeleteResourcePolicy"
             ]
         },
         "list": {

--- a/aws-redshiftserverless-namespace/docs/README.md
+++ b/aws-redshiftserverless-namespace/docs/README.md
@@ -290,10 +290,3 @@ Returns the <code>Status</code> value.
 
 Returns the <code>CreationDate</code> value.
 
-#### AdminPasswordSecretArn
-
-Returns the <code>AdminPasswordSecretArn</code> value.
-
-#### AdminPasswordSecretKmsKeyId
-
-Returns the <code>AdminPasswordSecretKmsKeyId</code> value.

--- a/aws-redshiftserverless-namespace/docs/namespace.md
+++ b/aws-redshiftserverless-namespace/docs/namespace.md
@@ -8,12 +8,33 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 <pre>
 {
+    "<a href="#adminpasswordsecretarn" title="AdminPasswordSecretArn">AdminPasswordSecretArn</a>" : <i>String</i>,
+    "<a href="#adminpasswordsecretkmskeyid" title="AdminPasswordSecretKmsKeyId">AdminPasswordSecretKmsKeyId</a>" : <i>String</i>
 }
 </pre>
 
 ### YAML
 
 <pre>
+<a href="#adminpasswordsecretarn" title="AdminPasswordSecretArn">AdminPasswordSecretArn</a>: <i>String</i>
+<a href="#adminpasswordsecretkmskeyid" title="AdminPasswordSecretKmsKeyId">AdminPasswordSecretKmsKeyId</a>: <i>String</i>
 </pre>
 
 ## Properties
+
+#### AdminPasswordSecretArn
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### AdminPasswordSecretKmsKeyId
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-redshiftserverless-namespace/docs/tag.md
+++ b/aws-redshiftserverless-namespace/docs/tag.md
@@ -43,3 +43,4 @@ _Type_: String
 _Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-redshiftserverless-namespace/resource-role.yaml
+++ b/aws-redshiftserverless-namespace/resource-role.yaml
@@ -36,7 +36,10 @@ Resources:
                 - "kms:Decrypt"
                 - "kms:DescribeKey"
                 - "kms:Encrypt"
+                - "kms:GenerateDataKey"
+                - "kms:GenerateDataKeyPair"
                 - "kms:ListGrants"
+                - "kms:RetireGrant"
                 - "kms:RevokeGrant"
                 - "kms:ScheduleKeyDeletion"
                 - "kms:TagResource"
@@ -49,6 +52,12 @@ Resources:
                 - "redshift:DeleteResourcePolicy"
                 - "redshift:GetResourcePolicy"
                 - "redshift:PutResourcePolicy"
+                - "secretsmanager:CreateSecret"
+                - "secretsmanager:DeleteSecret"
+                - "secretsmanager:DescribeSecret"
+                - "secretsmanager:RotateSecret"
+                - "secretsmanager:TagResource"
+                - "secretsmanager:UpdateSecret"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/Translator.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/Translator.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -64,6 +66,27 @@ public class Translator {
             .collect(Collectors.toList());
   }
 
+  /*
+    This function is to return the iam role in the same format as input iam roles.
+    Instead of modifying the schema for backward compatibitlity we use regex to extract the iam role.
+    'IamRole(applyStatus=null, iamRoleArn=arn:aws:iam::254260483320:role/contracttest9nfdg-redshif-RedshiftServerlessNamespa-nAxEywsQousB)'
+   */
+  static List<String> translateIamRoles(final List<String> iamRoles) {
+    return Optional.ofNullable(iamRoles).orElse(Collections.emptyList())
+            .stream()
+            .map(iamRole -> {
+              Pattern iamPattern = Pattern.compile("(arn:aws.*?:iam::[0-9]{12}?:role/[a-zA-Z0-9_+=,.@-]{1,64})");
+              Matcher matcher = iamPattern.matcher(iamRole);
+              if (matcher.find()){
+                return matcher.group(0);
+              }
+              // Case for invalid arn format provided. This is added as a precaution
+              // Service API call to RACS will throw error in case user provides invalid ARN and this wouldnt be reachable.
+              return null;
+            }).filter (iamRole->iamRole!=null)
+            .collect(Collectors.toList());
+  }
+
   /**
    * Request to read a resource
    * @param model resource model
@@ -86,7 +109,7 @@ public class Translator {
             .adminUsername(awsResponse.namespace().adminUsername())
             .dbName(awsResponse.namespace().dbName())
             .defaultIamRoleArn(awsResponse.namespace().defaultIamRoleArn())
-            .iamRoles(awsResponse.namespace().iamRoles())
+            .iamRoles(translateIamRoles(awsResponse.namespace().iamRoles()))
             .kmsKeyId(awsResponse.namespace().kmsKeyId())
             .logExports(awsResponse.namespace().logExportsAsStrings())
             .namespaceName(awsResponse.namespace().namespaceName())
@@ -197,7 +220,7 @@ public class Translator {
             .dbName(namespace.dbName())
             .kmsKeyId(namespace.kmsKeyId())
             .defaultIamRoleArn(namespace.defaultIamRoleArn())
-            .iamRoles(namespace.iamRoles())
+            .iamRoles(translateIamRoles(namespace.iamRoles()))
             .logExports(namespace.logExportsAsStrings())
             .status(namespace.statusAsString())
             .creationDate(namespace.creationDate() == null ? null : namespace.creationDate().toString())

--- a/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/AbstractTestBase.java
+++ b/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/AbstractTestBase.java
@@ -67,7 +67,7 @@ public class AbstractTestBase {
     DB_NAME = "DummyDBName";
     KMS_KEY_ID = "DummyKmsKeyId";
     DEFAULT_IAM_ROLE_ARN = "DummyDefaultIAMRoleArn";
-    IAM_ROLES = Arrays.asList("DummyIAMRole");
+    IAM_ROLES = Arrays.asList("arn:aws-abc:iam::123456789012:role/12345678-newrole");
     LOG_EXPORTS = Arrays.asList("DummyLogExports");
     STATUS = "available";
     CREATION_DATE = Instant.parse("9999-01-01T00:00:00Z");

--- a/aws-redshiftserverless-namespace/template.yml
+++ b/aws-redshiftserverless-namespace/template.yml
@@ -13,11 +13,11 @@ Resources:
     Properties:
       Handler: software.amazon.redshiftserverless.namespace.HandlerWrapper::handleRequest
       Runtime: java8
-      CodeUri: ./target/aws-redshiftserverless-namespace-handler-1.0-SNAPSHOT.jar
+      CodeUri: ./target/aws-redshiftserverless-namespace-1.0.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshiftserverless.namespace.HandlerWrapper::testEntrypoint
       Runtime: java8
-      CodeUri: ./target/aws-redshiftserverless-namespace-handler-1.0-SNAPSHOT.jar
+      CodeUri: ./target/aws-redshiftserverless-namespace-1.0.jar


### PR DESCRIPTION
This CR contains changes in schema.json for namespace resource. This schema change adds the necessary policy changes to support resource policy and aws secrets manager integration for namespace resource. This CR also contains change for IAMRoles translator which is currently being returned differently by RACS. We have used regex for backward compatability as the CT expect it to be list of strings with just IAM role ARN.

Testing:
1. Run changes to test handler locally a. source <pythonenv>/bin/activate && aws configure b. cd <resource> && sam local start-lambda c. cfn invoke resource CREATE <payload.json>

2. Run CT in personal account a. aws s3 cp build/packaging_additional_published_artifacts/aws-redshiftserverless-namespace.zip s3://vramanet-cfn-test-local b. docker run --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \ --env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \ --env AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \ --env AWS_DEFAULT_REGION=us-west-2 \ -p 9000:8080 public.ecr.aws/j9c3o4f9/contract-tests:latest c. curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d '{ "TypeName": "AWS::RedshiftServerless::Namespace", "Bucket": "vramanet-cfn-test-local", "Key": "aws-redshiftserverless-namespace.zip" }'

Modified translator iam roles to ignore invalid arns

This commit contains minor changes per feedback to add regex for aws partition and added valid arn extractor as per ARN role name rules. This CR also ignores invalid role Arn format in output. This is added as as an extra precaution as RACS does throw error in such cases

Modified pattern matcher regex

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
