### PR TITLE
Schema changes required to deploy workgroup

### DIFF
--- a/aws-redshiftserverless-workgroup/aws-redshiftserverless-workgroup.json
+++ b/aws-redshiftserverless-workgroup/aws-redshiftserverless-workgroup.json
@@ -325,7 +325,8 @@
                 "ec2:DescribeSubnets",
                 "ec2:DescribeAccountAttributes",
                 "ec2:DescribeAvailabilityZones",
-                "redshift-serverless:CreateWorkgroup"
+                "redshift-serverless:CreateWorkgroup",
+                "redshift-serverless:GetWorkgroup"
             ]
         },
         "read": {
@@ -365,6 +366,7 @@
                 "ec2:DescribeSubnets",
                 "ec2:DescribeAccountAttributes",
                 "ec2:DescribeAvailabilityZones",
+                "redshift-serverless:GetWorkgroup",
                 "redshift-serverless:DeleteWorkgroup"
             ]
         },


### PR DESCRIPTION
This CR contains schema changes required to deploy workgroup. Resource Policy changes added an extra call to get workgroup which would need schema changes as new endpoint permissions are required.

Testing:
1. Build artifacts and copy to your bucket ```bash bb && cp <Packagefolder>/build/packaging_additional_published_artifacts/ ```
2. Local Contract Tests expect credentials to be present in terminal before execution. ```bash export ISENGARD_PRODUCTION_ACCOUNT=false export AWS_ACCESS_KEY_ID=<AWS_ACCESS_KEY_ID> export AWS_SECRET_ACCESS_KEY=<AWS_SECRET_ACCESS_KEY> export AWS_SESSION_TOKEN=<AWS_SESSION_TOKEN> ```
3. Run a docker image that deploys resources to run CTV2 in your account ```bash docker run --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \ --env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \ --env AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \ --env AWS_DEFAULT_REGION=us-west-2 \ -p 9000:8080 public.ecr.aws/j9c3o4f9/contract-tests:latest ```
4. In a separate terminal window, invoke CTV2 ```bash curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d '{ "TypeName": "<ResourceType>", "Bucket": "<S3_Artifact_Bucket>", "Key": "<artifact_zip_file>" }' ```
5. Go to Step function and verify if state machine is created and the execution for the above invocation is successful for that resource

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
