### PR TITLE
Modified schema permissions for workgroup dependencies to deploy

### DIFF
--- a/aws-redshiftserverless-workgroup/aws-redshiftserverless-workgroup.json
+++ b/aws-redshiftserverless-workgroup/aws-redshiftserverless-workgroup.json
@@ -325,7 +325,9 @@
                 "ec2:DescribeSubnets",
                 "ec2:DescribeAccountAttributes",
                 "ec2:DescribeAvailabilityZones",
-                "redshift-serverless:CreateWorkgroup"
+                "redshift-serverless:CreateNamespace",
+                "redshift-serverless:CreateWorkgroup",
+                "redshift-serverless:GetWorkgroup"
             ]
         },
         "read": {
@@ -365,6 +367,7 @@
                 "ec2:DescribeSubnets",
                 "ec2:DescribeAccountAttributes",
                 "ec2:DescribeAvailabilityZones",
+                "redshift-serverless:GetWorkgroup",
                 "redshift-serverless:DeleteWorkgroup"
             ]
         },

--- a/aws-redshiftserverless-workgroup/resource-role.yaml
+++ b/aws-redshiftserverless-workgroup/resource-role.yaml
@@ -37,6 +37,7 @@ Resources:
                 - "ec2:DescribeSecurityGroups"
                 - "ec2:DescribeSubnets"
                 - "ec2:DescribeVpcAttribute"
+                - "redshift-serverless:CreateNamespace"
                 - "redshift-serverless:CreateWorkgroup"
                 - "redshift-serverless:DeleteWorkgroup"
                 - "redshift-serverless:GetWorkgroup"


### PR DESCRIPTION
This change contains schema changes for dependencies to deploy. This is required because during build schema permissions are converted to resource-role which is used to execute contract tests.The same permissions apply to deployment of dependencies as well. CT dependencies deployment uses the same role created in resource-role.yaml

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
