### PR TITLE
Modified schema permissions for workgroup dependencies to deploy

### DIFF
--- a/aws-redshiftserverless-workgroup/.rpdk-config
+++ b/aws-redshiftserverless-workgroup/.rpdk-config
@@ -24,5 +24,7 @@
         "codegen_template_path": "guided_aws",
         "protocolVersion": "2.0.0"
     },
-    "executableEntrypoint": "software.amazon.redshiftserverless.workgroup.HandlerWrapperExecutable"
+    "logProcessorEnabled": "true",
+    "executableEntrypoint": "software.amazon.redshiftserverless.workgroup.HandlerWrapperExecutable",
+    "contractSettings": {}
 }

--- a/aws-redshiftserverless-workgroup/aws-redshiftserverless-workgroup.json
+++ b/aws-redshiftserverless-workgroup/aws-redshiftserverless-workgroup.json
@@ -325,6 +325,7 @@
                 "ec2:DescribeSubnets",
                 "ec2:DescribeAccountAttributes",
                 "ec2:DescribeAvailabilityZones",
+                "redshift-serverless:CreateNamespace",
                 "redshift-serverless:CreateWorkgroup",
                 "redshift-serverless:GetWorkgroup"
             ]

--- a/aws-redshiftserverless-workgroup/docs/README.md
+++ b/aws-redshiftserverless-workgroup/docs/README.md
@@ -53,6 +53,8 @@ Properties:
 
 #### WorkgroupName
 
+The name of the workgroup.
+
 _Required_: Yes
 
 _Type_: String
@@ -66,6 +68,8 @@ _Pattern_: <code>^(?=^[a-z0-9-]+$).{3,64}$</code>
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### NamespaceName
+
+The namespace the workgroup is associated with.
 
 _Required_: No
 
@@ -81,6 +85,8 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 #### BaseCapacity
 
+The base compute capacity of the workgroup in Redshift Processing Units (RPUs).
+
 _Required_: No
 
 _Type_: Integer
@@ -88,6 +94,8 @@ _Type_: Integer
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### MaxCapacity
+
+The max compute capacity of the workgroup in Redshift Processing Units (RPUs).
 
 _Required_: No
 
@@ -97,6 +105,8 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### EnhancedVpcRouting
 
+The value that specifies whether to enable enhanced virtual private cloud (VPC) routing, which forces Amazon Redshift Serverless to route traffic through your VPC.
+
 _Required_: No
 
 _Type_: Boolean
@@ -104,6 +114,8 @@ _Type_: Boolean
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### ConfigParameters
+
+A list of parameters to set for finer control over a database. Available options are datestyle, enable_user_activity_logging, query_group, search_path, max_query_execution_time, and require_ssl.
 
 _Required_: No
 
@@ -113,6 +125,8 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### SecurityGroupIds
 
+A list of security group IDs to associate with the workgroup.
+
 _Required_: No
 
 _Type_: List of String
@@ -120,6 +134,8 @@ _Type_: List of String
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### SubnetIds
+
+A list of subnet IDs the workgroup is associated with.
 
 _Required_: No
 
@@ -129,6 +145,8 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### PubliclyAccessible
 
+A value that specifies whether the workgroup can be accessible from a public network.
+
 _Required_: No
 
 _Type_: Boolean
@@ -137,6 +155,8 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### Port
 
+The custom port to use when connecting to a workgroup. Valid port ranges are 5431-5455 and 8191-8215. The default is 5439.
+
 _Required_: No
 
 _Type_: Integer
@@ -144,6 +164,8 @@ _Type_: Integer
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### Tags
+
+The map of the key-value pairs used to tag the workgroup.
 
 _Required_: No
 
@@ -254,3 +276,4 @@ Returns the <code>PubliclyAccessible</code> value.
 #### CreationDate
 
 Returns the <code>CreationDate</code> value.
+

--- a/aws-redshiftserverless-workgroup/docs/configparameter.md
+++ b/aws-redshiftserverless-workgroup/docs/configparameter.md
@@ -41,3 +41,4 @@ _Type_: String
 _Maximum Length_: <code>15000</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-redshiftserverless-workgroup/docs/tag.md
+++ b/aws-redshiftserverless-workgroup/docs/tag.md
@@ -43,3 +43,4 @@ _Type_: String
 _Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-redshiftserverless-workgroup/docs/workgroup.md
+++ b/aws-redshiftserverless-workgroup/docs/workgroup.md
@@ -38,3 +38,4 @@ _Required_: No
 _Type_: <a href="endpoint.md">Endpoint</a>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-redshiftserverless-workgroup/resource-role.yaml
+++ b/aws-redshiftserverless-workgroup/resource-role.yaml
@@ -37,6 +37,7 @@ Resources:
                 - "ec2:DescribeSecurityGroups"
                 - "ec2:DescribeSubnets"
                 - "ec2:DescribeVpcAttribute"
+                - "redshift-serverless:CreateNamespace"
                 - "redshift-serverless:CreateWorkgroup"
                 - "redshift-serverless:DeleteWorkgroup"
                 - "redshift-serverless:GetWorkgroup"


### PR DESCRIPTION
This change contains schema changes for dependencies to deploy. This is required because during build schema permissions are converted to resource-role which is used to execute contract tests.The same permissions apply to deployment of dependencies as well. CT dependencies deployment uses the same role created in resource-role.yaml

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
