### PR TITLE
Reverting rpdk config file changes

### DIFF
--- a/aws-redshiftserverless-namespace/.rpdk-config
+++ b/aws-redshiftserverless-namespace/.rpdk-config
@@ -20,8 +20,5 @@
         ],
         "codegen_template_path": "guided_aws",
         "protocolVersion": "2.0.0"
-    },
-    "logProcessorEnabled": "true",
-    "executableEntrypoint": "software.amazon.redshiftserverless.namespace.HandlerWrapperExecutable",
-    "contractSettings": {}
+    }
 }

--- a/aws-redshiftserverless-workgroup/.rpdk-config
+++ b/aws-redshiftserverless-workgroup/.rpdk-config
@@ -23,8 +23,5 @@
         ],
         "codegen_template_path": "guided_aws",
         "protocolVersion": "2.0.0"
-    },
-    "logProcessorEnabled": "true",
-    "executableEntrypoint": "software.amazon.redshiftserverless.workgroup.HandlerWrapperExecutable",
-    "contractSettings": {}
+    }
 }


### PR DESCRIPTION
This commit reverts rpdk config changes from previous commit. The previous commit overrides contract test role policy causing contract to fail.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
