### PR TITLE
Upgrade CFN resources runtime to JDK17

### DIFF
--- a/aws-redshiftserverless-namespace/.rpdk-config
+++ b/aws-redshiftserverless-namespace/.rpdk-config
@@ -20,6 +20,5 @@
         ],
         "codegen_template_path": "guided_aws",
         "protocolVersion": "2.0.0"
-    },
-    "executableEntrypoint": "software.amazon.redshiftserverless.namespace.HandlerWrapperExecutable"
+    }
 }

--- a/aws-redshiftserverless-namespace/.rpdk-config
+++ b/aws-redshiftserverless-namespace/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::RedshiftServerless::Namespace",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java17",
     "entrypoint": "software.amazon.redshiftserverless.namespace.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.redshiftserverless.namespace.HandlerWrapper::testEntrypoint",
     "settings": {
@@ -20,5 +20,6 @@
         ],
         "codegen_template_path": "guided_aws",
         "protocolVersion": "2.0.0"
-    }
+    },
+    "executableEntrypoint": "software.amazon.redshiftserverless.namespace.HandlerWrapperExecutable"
 }

--- a/aws-redshiftserverless-namespace/template.yml
+++ b/aws-redshiftserverless-namespace/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshiftserverless.namespace.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-redshiftserverless-namespace-1.0.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshiftserverless.namespace.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-redshiftserverless-namespace-1.0.jar


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Upgrade CFN resources runtime to JDK17 from JDK8 as JDK8 is on deprecation path

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
