### PR TITLE
Fix for regions where resource policy not supported to not throw error

### DIFF
--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/ReadHandler.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/ReadHandler.java
@@ -96,7 +96,7 @@ public class ReadHandler extends BaseHandlerStd {
         } catch (InvalidPolicyException | UnsupportedOperationException e) {
           /* ResourcePolicy is not enabled in all regions, we should handle unsupported operation exception
           if NamespaceResourcePolicy is not added as a property while creating Namespace resource. */
-          if(!containsResourcePolicy && e.statusCode() == RESOURCE_POLICY_UNSUPPORTED_ERR_STATUS_CODE &&
+          if(e.statusCode() == RESOURCE_POLICY_UNSUPPORTED_ERR_STATUS_CODE &&
                   e.awsErrorDetails().errorMessage().contains(RESOURCE_POLICY_UNSUPPORTED_ERROR)) {
               logger.log(e.getMessage());
               return noOpNamespaceResourcePoliy(awsRequest);
@@ -107,7 +107,7 @@ public class ReadHandler extends BaseHandlerStd {
             /* This error handling is required for backward compatibility. Without this exception handling, existing customers creating
             or updating their namespace will see an error with permission issues - "is not authorized to perform: redshift:GetResourcePolicy",
             as Read handler is trying to hit getResourcePolicy APIs to get namespaceResourcePolicy details.*/
-            if(!containsResourcePolicy && e.statusCode() == GET_RESOURCE_POLICY_ERR_STATUS_CODE &&
+            if(e.statusCode() == GET_RESOURCE_POLICY_ERR_STATUS_CODE &&
                     e.awsErrorDetails().errorMessage().contains(GET_RESOURCE_POLICY_ERROR)) {
                 logger.log(String.format("RedshiftException:  %s", e.getMessage()));
                 return noOpNamespaceResourcePoliy(awsRequest);


### PR DESCRIPTION
during create

Currently we are seeing error during create namespace in regions where resource policy is not enabled. If a customer provides a resource policy during create and that region doesnt support resource policy we should not throw any error.

Testing:
1. Tested in region us-west-1 where resource policy API is not supported yet.
2. enable virtualenv
3. cd aws-redshiftserverless-namespace && sam local start-lambda
4. In anothet terminal enable virtualenev
5. cfn invoke resource CREATE local-tests-artifacts/create-aws-redshiftserverless-namespace.json

Results:
cfn=== Handler response ===
{
  "status": "SUCCESS",
  "callbackDelaySeconds": 0,
  "resourceModel": {
    "AdminUsername": "admin",
    "DbName": "dev",
    "IamRoles": [],
    "KmsKeyId": "AWS_OWNED_KMS_KEY",
    "LogExports": [
      "userlog"
    ],
    "Namespace": {
      "NamespaceArn": "arn:aws:redshift-serverless:us-west-1:254260483320:namespace/491ac828-97a8-4ed2-b7b1-f5f242a694a3",
      "NamespaceId": "491ac828-97a8-4ed2-b7b1-f5f242a694a3",
      "NamespaceName": "ns-cfn-vramanet-test-xs7mtkvog2zfey",
      "AdminUsername": "admin",
      "DbName": "dev",
      "KmsKeyId": "AWS_OWNED_KMS_KEY",
      "IamRoles": [],
      "LogExports": [
        "userlog"
      ],
      "Status": "AVAILABLE",
      "CreationDate": "2024-02-08T11:55:45.950Z"
    },
    "NamespaceName": "ns-cfn-vramanet-test-xs7mtkvog2zfey"
  }
}

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
