### PR TITLE
JDK17 runtime upgrde for workgroup resource

### DIFF
--- a/aws-redshiftserverless-workgroup/.rpdk-config
+++ b/aws-redshiftserverless-workgroup/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::RedshiftServerless::Workgroup",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java17",
     "entrypoint": "software.amazon.redshiftserverless.workgroup.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.redshiftserverless.workgroup.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-redshiftserverless-workgroup/template.yml
+++ b/aws-redshiftserverless-workgroup/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshiftserverless.workgroup.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-redshiftserverless-workgroup-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshiftserverless.workgroup.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-redshiftserverless-workgroup-handler-1.0-SNAPSHOT.jar


### PR DESCRIPTION
Security Compliance dictates to upgrade the JDK runtime version for resources to be upgraded from JDK8. This CR contains the change for runtime upgrade from JDK8 to JDK17.

Testing:
1. Local contract test passing with latest JDK17 upgrade.
2. Local Handler invocation passed successfully.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
