### PR TITLE
Resolved merge conflict with revert #47

### DIFF
--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/ReadHandler.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/ReadHandler.java
@@ -16,6 +16,8 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 public class ReadHandler extends BaseHandlerStd {
+    private Logger logger;
+    private boolean containsResourcePolicy = false;
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
         final AmazonWebServicesClientProxy proxy,

--- a/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/ReadHandlerTest.java
+++ b/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/ReadHandlerTest.java
@@ -1,14 +1,8 @@
 package software.amazon.redshiftserverless.namespace;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
-<<<<<<< HEAD
-import java.util.Collections;
 import java.util.stream.Stream;
-=======
->>>>>>> parent of 27dfc76 (Added cross region snapshot copy parameters support (#42))
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -20,14 +14,8 @@ import software.amazon.awssdk.services.redshift.model.RedshiftException;
 import software.amazon.awssdk.services.redshift.model.UnsupportedOperationException;
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
 import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceRequest;
-<<<<<<< HEAD
-import software.amazon.awssdk.services.redshiftserverless.model.ListSnapshotCopyConfigurationsRequest;
-import software.amazon.awssdk.services.redshiftserverless.model.ListSnapshotCopyConfigurationsResponse;
-import software.amazon.awssdk.services.redshiftserverless.model.SnapshotCopyConfiguration;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
-=======
->>>>>>> parent of 27dfc76 (Added cross region snapshot copy parameters support (#42))
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -154,7 +142,6 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .thenThrow((Throwable) createExceptionWithBuilder(exceptionClass));
 
         if (expectedException == null) {
-            when(proxyClient.client().listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class))).thenReturn(getSnapshotCopyConfigurationsResponseSdk());
             final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
             assertThat(response).isNotNull();
             assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixed merge conflicts

*Testing*

```
[INFO] Scanning for projects...
[INFO] 
[INFO] --< software.amazon.redshiftserverless.namespace:aws-redshiftserverless-namespace-handler >--
[INFO] Building aws-redshiftserverless-namespace-handler 1.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- jacoco:0.8.4:prepare-agent (default) @ aws-redshiftserverless-namespace-handler ---
[INFO] argLine set to -javaagent:/Users/donwimo/.m2/repository/org/jacoco/org.jacoco.agent/0.8.4/org.jacoco.agent-0.8.4-runtime.jar=destfile=/Volumes/workplace/aws-cloudformation-resource-providers-redshift-serverless/aws-redshiftserverless-namespace/target/jacoco.exec,excludes=**/BaseConfiguration*:**/BaseHandler*:**/HandlerWrapper*:**/ResourceModel*
[INFO] 
[INFO] --- exec:1.6.0:exec (generate) @ aws-redshiftserverless-namespace-handler ---
Resource schema is valid.
Generated files for AWS::RedshiftServerless::Namespace
[INFO] 
[INFO] --- build-helper:3.0.0:add-source (add-source) @ aws-redshiftserverless-namespace-handler ---
[INFO] Source directory: /Volumes/workplace/aws-cloudformation-resource-providers-redshift-serverless/aws-redshiftserverless-namespace/target/generated-sources/rpdk added.
[INFO] 
[INFO] --- resources:2.4:resources (default-resources) @ aws-redshiftserverless-namespace-handler ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 1 resource
[INFO] 
[INFO] --- compiler:3.8.1:compile (default-compile) @ aws-redshiftserverless-namespace-handler ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 19 source files to /Volumes/workplace/aws-cloudformation-resource-providers-redshift-serverless/aws-redshiftserverless-namespace/target/classes
[INFO] 
[INFO] --- resources:2.4:testResources (default-testResources) @ aws-redshiftserverless-namespace-handler ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /Volumes/workplace/aws-cloudformation-resource-providers-redshift-serverless/aws-redshiftserverless-namespace/src/test/resources
[INFO] 
[INFO] --- compiler:3.8.1:testCompile (default-testCompile) @ aws-redshiftserverless-namespace-handler ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 6 source files to /Volumes/workplace/aws-cloudformation-resource-providers-redshift-serverless/aws-redshiftserverless-namespace/target/test-classes
[INFO] 
[INFO] --- surefire:3.0.0-M3:test (default-test) @ aws-redshiftserverless-namespace-handler ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running software.amazon.redshiftserverless.namespace.CreateHandlerTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.508 s - in software.amazon.redshiftserverless.namespace.CreateHandlerTest
[INFO] Running software.amazon.redshiftserverless.namespace.UpdateHandlerTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in software.amazon.redshiftserverless.namespace.UpdateHandlerTest
[INFO] Running software.amazon.redshiftserverless.namespace.ReadHandlerTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.079 s - in software.amazon.redshiftserverless.namespace.ReadHandlerTest
[INFO] Running software.amazon.redshiftserverless.namespace.DeleteHandlerTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in software.amazon.redshiftserverless.namespace.DeleteHandlerTest
[INFO] Running software.amazon.redshiftserverless.namespace.ListHandlerTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.573 s - in software.amazon.redshiftserverless.namespace.ListHandlerTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.4:report (report) @ aws-redshiftserverless-namespace-handler ---
[INFO] Loading execution data file /Volumes/workplace/aws-cloudformation-resource-providers-redshift-serverless/aws-redshiftserverless-namespace/target/jacoco.exec
[INFO] Analyzed bundle 'aws-redshiftserverless-namespace-handler' with 11 classes
[INFO] 
[INFO] --- jar:3.3.0:jar (default-jar) @ aws-redshiftserverless-namespace-handler ---
[INFO] Building jar: /Volumes/workplace/aws-cloudformation-resource-providers-redshift-serverless/aws-redshiftserverless-namespace/target/aws-redshiftserverless-namespace-handler-1.0-SNAPSHOT.jar
[INFO] 
[INFO] --- shade:2.3:shade (default) @ aws-redshiftserverless-namespace-handler ---
[INFO] Including software.amazon.awssdk:redshiftserverless:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:protocol-core:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:aws-json-protocol:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:third-party-jackson-core:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:http-auth-aws:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:http-auth-spi:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:http-auth:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:identity-spi:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:http-client-spi:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:regions:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:annotations:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:metrics-spi:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:json-utils:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:endpoints-spi:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:apache-client:jar:2.22.5 in the shaded jar.
[INFO] Including org.apache.httpcomponents:httpclient:jar:4.5.13 in the shaded jar.
[INFO] Including org.apache.httpcomponents:httpcore:jar:4.4.13 in the shaded jar.
[INFO] Including software.amazon.awssdk:netty-nio-client:jar:2.22.5 in the shaded jar.
[INFO] Including io.netty:netty-codec-http:jar:4.1.100.Final in the shaded jar.
[INFO] Including io.netty:netty-codec-http2:jar:4.1.100.Final in the shaded jar.
[INFO] Including io.netty:netty-codec:jar:4.1.100.Final in the shaded jar.
[INFO] Including io.netty:netty-transport:jar:4.1.100.Final in the shaded jar.
[INFO] Including io.netty:netty-common:jar:4.1.100.Final in the shaded jar.
[INFO] Including io.netty:netty-buffer:jar:4.1.100.Final in the shaded jar.
[INFO] Including io.netty:netty-handler:jar:4.1.100.Final in the shaded jar.
[INFO] Including io.netty:netty-transport-native-unix-common:jar:4.1.100.Final in the shaded jar.
[INFO] Including io.netty:netty-transport-classes-epoll:jar:4.1.100.Final in the shaded jar.
[INFO] Including io.netty:netty-resolver:jar:4.1.100.Final in the shaded jar.
[INFO] Including software.amazon.awssdk:redshift:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:aws-query-protocol:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:aws-core:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:profiles:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.eventstream:eventstream:jar:1.0.1 in the shaded jar.
[INFO] Including software.amazon.awssdk:sdk-core:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:checksums-spi:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:checksums:jar:2.22.5 in the shaded jar.
[INFO] Including org.slf4j:slf4j-api:jar:1.7.30 in the shaded jar.
[INFO] Including org.reactivestreams:reactive-streams:jar:1.0.4 in the shaded jar.
[INFO] Including software.amazon.awssdk:utils:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:auth:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.cloudformation:aws-cloudformation-rpdk-java-plugin:jar:2.0.16 in the shaded jar.
[INFO] Including commons-codec:commons-codec:jar:1.14 in the shaded jar.
[INFO] Including software.amazon.cloudformation:aws-cloudformation-resource-schema:jar:2.0.8 in the shaded jar.
[INFO] Including com.github.erosb:everit-json-schema:jar:1.14.1 in the shaded jar.
[INFO] Including commons-validator:commons-validator:jar:1.7 in the shaded jar.
[INFO] Including commons-digester:commons-digester:jar:2.1 in the shaded jar.
[INFO] Including commons-collections:commons-collections:jar:3.2.2 in the shaded jar.
[INFO] Including com.damnhandy:handy-uri-templates:jar:2.1.8 in the shaded jar.
[INFO] Including com.google.re2j:re2j:jar:1.6 in the shaded jar.
[INFO] Including com.fasterxml.jackson.core:jackson-databind:jar:2.14.1 in the shaded jar.
[INFO] Including com.fasterxml.jackson.core:jackson-annotations:jar:2.14.1 in the shaded jar.
[INFO] Including com.fasterxml.jackson.core:jackson-core:jar:2.14.1 in the shaded jar.
[INFO] Including com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.14.1 in the shaded jar.
[INFO] Including com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.14.1 in the shaded jar.
[INFO] Skipping pom dependency com.fasterxml.jackson.module:jackson-modules-java8:pom:2.14.1 in the shaded jar.
[INFO] Including org.json:json:jar:20180813 in the shaded jar.
[INFO] Including com.amazonaws:aws-java-sdk-core:jar:1.12.367 in the shaded jar.
[INFO] Including commons-logging:commons-logging:jar:1.1.3 in the shaded jar.
[INFO] Including software.amazon.ion:ion-java:jar:1.0.2 in the shaded jar.
[INFO] Including joda-time:joda-time:jar:2.8.1 in the shaded jar.
[INFO] Including com.amazonaws:aws-lambda-java-core:jar:1.2.1 in the shaded jar.
[INFO] Including com.amazonaws:aws-lambda-java-log4j2:jar:1.5.1 in the shaded jar.
[INFO] Including com.amazonaws:aws-encryption-sdk-java:jar:2.2.0 in the shaded jar.
[INFO] Including org.bouncycastle:bcprov-ext-jdk15on:jar:1.67 in the shaded jar.
[INFO] Including com.amazonaws:aws-java-sdk-sts:jar:1.12.368 in the shaded jar.
[INFO] Including com.amazonaws:jmespath-java:jar:1.12.368 in the shaded jar.
[INFO] Including com.google.code.findbugs:annotations:jar:3.0.0 in the shaded jar.
[INFO] Including com.amazonaws:aws-java-sdk-kms:jar:1.12.368 in the shaded jar.
[INFO] Including software.amazon.awssdk:cloudformation:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:cloudwatch:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:cloudwatchevents:jar:2.22.5 in the shaded jar.
[INFO] Including software.amazon.awssdk:cloudwatchlogs:jar:2.22.5 in the shaded jar.
[INFO] Including commons-io:commons-io:jar:2.8.0 in the shaded jar.
[INFO] Including org.apache.commons:commons-lang3:jar:3.9 in the shaded jar.
[INFO] Including org.apache.commons:commons-collections4:jar:4.4 in the shaded jar.
[INFO] Including com.google.guava:guava:jar:31.1-jre in the shaded jar.
[INFO] Including com.google.guava:failureaccess:jar:1.0.1 in the shaded jar.
[INFO] Including com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava in the shaded jar.
[INFO] Including com.google.code.findbugs:jsr305:jar:3.0.2 in the shaded jar.
[INFO] Including org.checkerframework:checker-qual:jar:3.12.0 in the shaded jar.
[INFO] Including com.google.errorprone:error_prone_annotations:jar:2.11.0 in the shaded jar.
[INFO] Including com.google.j2objc:j2objc-annotations:jar:1.3 in the shaded jar.
[INFO] Including com.diffplug.spotless:spotless-maven-plugin:jar:2.28.0 in the shaded jar.
[INFO] Including com.diffplug.spotless:spotless-lib:jar:2.31.0 in the shaded jar.
[INFO] Including com.diffplug.spotless:spotless-lib-extra:jar:2.31.0 in the shaded jar.
[INFO] Including com.googlecode.concurrent-trees:concurrent-trees:jar:2.6.1 in the shaded jar.
[INFO] Including org.codehaus.groovy:groovy-xml:jar:3.0.10 in the shaded jar.
[INFO] Including org.codehaus.groovy:groovy:jar:3.0.10 in the shaded jar.
[INFO] Including com.diffplug.durian:durian-core:jar:1.2.0 in the shaded jar.
[INFO] Including com.diffplug.durian:durian-collect:jar:1.2.0 in the shaded jar.
[INFO] Including org.codehaus.plexus:plexus-resources:jar:1.2.0 in the shaded jar.
[INFO] Including org.codehaus.plexus:plexus-utils:jar:3.4.1 in the shaded jar.
[INFO] Including javax.inject:javax.inject:jar:1 in the shaded jar.
[INFO] Including org.eclipse.jgit:org.eclipse.jgit:jar:5.13.1.202206130422-r in the shaded jar.
[INFO] Including com.googlecode.javaewah:JavaEWAH:jar:1.1.13 in the shaded jar.
[INFO] Including org.apache.logging.log4j:log4j-api:jar:2.17.1 in the shaded jar.
[INFO] Including org.apache.logging.log4j:log4j-core:jar:2.17.1 in the shaded jar.
[INFO] Including org.apache.logging.log4j:log4j-slf4j-impl:jar:2.13.3 in the shaded jar.
[WARNING] annotations-3.0.0.jar, jsr305-3.0.2.jar define 35 overlappping classes: 
[WARNING]   - javax.annotation.RegEx
[WARNING]   - javax.annotation.concurrent.Immutable
[WARNING]   - javax.annotation.meta.TypeQualifierDefault
[WARNING]   - javax.annotation.meta.TypeQualifier
[WARNING]   - javax.annotation.Syntax
[WARNING]   - javax.annotation.CheckForNull
[WARNING]   - javax.annotation.Nonnull
[WARNING]   - javax.annotation.CheckReturnValue
[WARNING]   - javax.annotation.meta.TypeQualifierNickname
[WARNING]   - javax.annotation.MatchesPattern
[WARNING]   - 25 more...
[WARNING] bcprov-ext-jdk15on-1.67.jar, log4j-api-2.17.1.jar, jackson-core-2.14.1.jar, jackson-dataformat-cbor-2.14.1.jar, jackson-databind-2.14.1.jar, jackson-datatype-jsr310-2.14.1.jar define 1 overlappping classes: 
[WARNING]   - META-INF.versions.9.module-info
[WARNING] maven-shade-plugin has detected that some .class files
[WARNING] are present in two or more JARs. When this happens, only
[WARNING] one single version of the class is copied in the uberjar.
[WARNING] Usually this is not harmful and you can skeep these
[WARNING] warnings, otherwise try to manually exclude artifacts
[WARNING] based on mvn dependency:tree -Ddetail=true and the above
[WARNING] output
[WARNING] See http://docs.codehaus.org/display/MAVENUSER/Shade+Plugin
[INFO] Replacing original artifact with shaded artifact.
[INFO] Replacing /Volumes/workplace/aws-cloudformation-resource-providers-redshift-serverless/aws-redshiftserverless-namespace/target/aws-redshiftserverless-namespace-handler-1.0-SNAPSHOT.jar with /Volumes/workplace/aws-cloudformation-resource-providers-redshift-serverless/aws-redshiftserverless-namespace/target/aws-redshiftserverless-namespace-handler-1.0-SNAPSHOT-shaded.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  23.653 s
[INFO] Finished at: 2024-03-06T11:05:58+11:00
[INFO] ------------------------------------------------------------------------
[WARNING] 
[WARNING] Plugin validation issues were detected in 7 plugin(s)
[WARNING] 
[WARNING]  * org.jacoco:jacoco-maven-plugin:0.8.4
[WARNING]  * org.apache.maven.plugins:maven-compiler-plugin:3.8.1
[WARNING]  * org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3
[WARNING]  * org.codehaus.mojo:exec-maven-plugin:1.6.0
[WARNING]  * org.apache.maven.plugins:maven-shade-plugin:2.3
[WARNING]  * org.codehaus.mojo:build-helper-maven-plugin:3.0.0
[WARNING]  * org.apache.maven.plugins:maven-resources-plugin:2.4
[WARNING] 
[WARNING] For more or less details, use 'maven.plugin.validation' property with one of the values (case insensitive): [BRIEF, DEFAULT, VERBOSE]
[WARNING] 
Process finished with exit code 0
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
