### PR TITLE
Retry create/update on workgroup conflict exception

### DIFF
--- a/aws-redshiftserverless-workgroup/.rpdk-config
+++ b/aws-redshiftserverless-workgroup/.rpdk-config
@@ -23,5 +23,6 @@
         ],
         "codegen_template_path": "guided_aws",
         "protocolVersion": "2.0.0"
-    }
+    },
+    "executableEntrypoint": "software.amazon.redshiftserverless.workgroup.HandlerWrapperExecutable"
 }

--- a/aws-redshiftserverless-workgroup/pom.xml
+++ b/aws-redshiftserverless-workgroup/pom.xml
@@ -72,6 +72,12 @@
             <version>5.5.0-M1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.5.0-M1</version>
+            <scope>test</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
         <dependency>
             <groupId>org.mockito</groupId>

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/BaseHandlerStd.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/BaseHandlerStd.java
@@ -1,6 +1,7 @@
 package software.amazon.redshiftserverless.workgroup;
 
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
+import software.amazon.awssdk.services.redshiftserverless.model.ConflictException;
 import software.amazon.awssdk.services.redshiftserverless.model.DeleteWorkgroupRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.RedshiftServerlessResponse;
@@ -18,6 +19,13 @@ import java.time.Duration;
 // Placeholder for the functionality that could be shared across Create/Read/Update/Delete/List Handlers
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
+
+    public static final String BUSY_WORKGROUP_RETRY_EXCEPTION_MESSAGE =
+            "There is an operation running on the existing workgroup";
+
+    protected static boolean isRetriableWorkgroupException(ConflictException exception) {
+        return exception.getMessage().contains(BUSY_WORKGROUP_RETRY_EXCEPTION_MESSAGE);
+    }
 
     protected static final Constant BACKOFF_STRATEGY = Constant.of()
             .timeout(Duration.ofMinutes(30L))

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/CallbackContext.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/CallbackContext.java
@@ -7,4 +7,5 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext {
+    int retryOnResourceNotFound = 5;
 }

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/ReadHandler.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/ReadHandler.java
@@ -6,12 +6,19 @@ import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupResp
 import software.amazon.awssdk.services.redshiftserverless.model.InternalServerException;
 import software.amazon.awssdk.services.redshiftserverless.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.redshiftserverless.model.ValidationException;
+import software.amazon.awssdk.services.redshiftserverless.model.WorkgroupStatus;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static software.amazon.cloudformation.proxy.ProgressEvent.progress;
 
 public class ReadHandler extends BaseHandlerStd {
     private Logger logger;
@@ -29,16 +36,45 @@ public class ReadHandler extends BaseHandlerStd {
                 .translateToServiceRequest(Translator::translateToReadRequest)
                 .makeServiceCall(this::readWorkgroup)
                 .handleError(this::readWorkgroupErrorHandler)
-                .done(awsResponse -> ProgressEvent.defaultSuccessHandler(Translator.translateFromReadResponse(awsResponse)));
+                .done(awsResponse -> getProgressEventFromReadWorkgroupResponse(awsResponse, callbackContext));
     }
 
     private GetWorkgroupResponse readWorkgroup(final GetWorkgroupRequest awsRequest,
                                                final ProxyClient<RedshiftServerlessClient> proxyClient) {
         GetWorkgroupResponse awsResponse;
-        awsResponse = proxyClient.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::getWorkgroup);
+            awsResponse = proxyClient.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::getWorkgroup);
 
-        logger.log(String.format("%s has successfully been read.", ResourceModel.TYPE_NAME));
-        return awsResponse;
+            logger.log(String.format("%s has successfully been read.", ResourceModel.TYPE_NAME));
+            return awsResponse;
+    }
+
+    /**
+     * We used to return operationStatus.SUCCESS for all workgroup statuses,
+     * including creating, deleting, modifying.
+     *
+     * When CFN contract test checks if the resource has been deleted by calling ReadHandler,
+     * and when the workgroup == DELETING, we should have returned in_progress to indicate the
+     * deletion is not finished, and contract test can't start creating the same resource again.
+     *
+     * Same scenario would cause customer issues too.
+     *
+     * @param getWorkgroupResponse
+     * @param ctx
+     * @return
+     */
+    private static ProgressEvent<ResourceModel, CallbackContext> getProgressEventFromReadWorkgroupResponse(GetWorkgroupResponse getWorkgroupResponse,
+                                                                                                    CallbackContext ctx) {
+        ResourceModel workgroupModel = Translator.translateFromReadResponse(getWorkgroupResponse);
+        List<WorkgroupStatus> inProgressWorkgroupStatuses = Arrays.asList(
+                WorkgroupStatus.CREATING,
+                WorkgroupStatus.DELETING,
+                WorkgroupStatus.MODIFYING
+        );
+        boolean isInProgress = inProgressWorkgroupStatuses.contains(getWorkgroupResponse.workgroup().status());
+
+        ProgressEvent<ResourceModel, CallbackContext> progressEvent = progress(workgroupModel, ctx);
+        progressEvent.setStatus(isInProgress ? OperationStatus.IN_PROGRESS : OperationStatus.SUCCESS);
+        return progressEvent;
     }
 
     private ProgressEvent<ResourceModel, CallbackContext> readWorkgroupErrorHandler(final GetWorkgroupRequest awsRequest,
@@ -48,13 +84,10 @@ public class ReadHandler extends BaseHandlerStd {
                                                                                     final CallbackContext context) {
         if (exception instanceof ResourceNotFoundException) {
             return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.NotFound);
-
         } else if (exception instanceof ValidationException) {
             return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.InvalidRequest);
-
         } else if (exception instanceof InternalServerException) {
             return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.InternalFailure);
-
         } else {
             return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.GeneralServiceException);
         }

--- a/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/CreateHandlerTest.java
+++ b/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/CreateHandlerTest.java
@@ -7,9 +7,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
+import software.amazon.awssdk.services.redshiftserverless.model.ConflictException;
 import software.amazon.awssdk.services.redshiftserverless.model.CreateWorkgroupRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupRequest;
+import software.amazon.awssdk.services.redshiftserverless.model.InternalServerException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
@@ -71,5 +74,70 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_retryOnConflictException() {
+        final CreateHandler handler = new CreateHandler();
+
+        final ResourceModel requestResourceModel = createRequestResourceModel();
+        final ResourceModel responseResourceModel = getReadResponseResourceModel();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(requestResourceModel)
+                .build();
+
+        ConflictException exception = ConflictException.builder()
+                .message("There is an operation running on the existing workgroup. Try again later.")
+                .build();
+
+        /**
+         * The Thread.sleep() is actually called here, making unit longer.
+         * MockStatic easily will need a Java version upgrade, then the Mockito upgrade,
+         * I'll leave the upgrade in another commit.
+         */
+        when(proxyClient.client().createWorkgroup(any(CreateWorkgroupRequest.class)))
+                .thenThrow(exception)
+                .thenReturn(createResponseSdk());
+        when(proxyClient.client().getWorkgroup(any(GetWorkgroupRequest.class))).thenReturn(getReadResponseSdk());
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(responseResourceModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_noRetryOnOtherException() throws InterruptedException {
+        final CreateHandler handler = new CreateHandler();
+        final ResourceModel requestResourceModel = createRequestResourceModel();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(requestResourceModel)
+                .build();
+
+        /**
+         * The Thread.sleep() is actually called here, making unit longer.
+         * MockStatic easily will need a Java version upgrade, then the Mockito upgrade,
+         * I'll leave the upgrade in another commit.
+         */
+        when(proxyClient.client().createWorkgroup(any(CreateWorkgroupRequest.class)))
+                .thenThrow(InternalServerException.builder()
+                        .message("test")
+                        .build());
+
+        final ProgressEvent<ResourceModel, CallbackContext> response =
+                handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo("test");
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InternalFailure);
     }
 }

--- a/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/ReadHandlerTest.java
+++ b/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/ReadHandlerTest.java
@@ -4,19 +4,30 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
+import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupRequest;
+import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupResponse;
+import software.amazon.awssdk.services.redshiftserverless.model.WorkgroupStatus;
+import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import java.lang.reflect.Method;
 import java.time.Duration;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -47,23 +58,41 @@ public class ReadHandlerTest extends AbstractTestBase {
         verifyNoMoreInteractions(sdkClient);
     }
 
-    @Test
-    public void handleRequest_SimpleSuccess() {
+    static Stream<Arguments> provideReadHandlerParams() {
+        return Stream.of(
+                Arguments.of(WorkgroupStatus.AVAILABLE, OperationStatus.SUCCESS),
+                Arguments.of(WorkgroupStatus.CREATING, OperationStatus.IN_PROGRESS),
+                Arguments.of(WorkgroupStatus.DELETING, OperationStatus.IN_PROGRESS),
+                Arguments.of(WorkgroupStatus.MODIFYING, OperationStatus.IN_PROGRESS),
+                Arguments.of(WorkgroupStatus.UNKNOWN_TO_SDK_VERSION, OperationStatus.SUCCESS)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideReadHandlerParams")
+    public void handleRequest_callReturns(
+            WorkgroupStatus returnedWgStatus,
+            OperationStatus expectedOperationStatus
+    ) {
         final ReadHandler handler = new ReadHandler();
 
-        final ResourceModel requestResourceModel = getReadRequestResourceModel();
-        final ResourceModel responseResourceModel = getReadResponseResourceModel();
+        GetWorkgroupResponse defaultResponse = getReadResponseSdk();
+        GetWorkgroupResponse testResponse = defaultResponse.toBuilder()
+                .workgroup(defaultResponse.workgroup().toBuilder().status(returnedWgStatus).build())
+                .build();
 
+        when(proxyClient.client().getWorkgroup(any(GetWorkgroupRequest.class))).thenReturn(testResponse);
+
+        final ResourceModel requestResourceModel = getReadRequestResourceModel();
+        final ResourceModel responseResourceModel = Translator.translateFromReadResponse(testResponse);
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(requestResourceModel)
                 .build();
 
-        when(proxyClient.client().getWorkgroup(any(GetWorkgroupRequest.class))).thenReturn(getReadResponseSdk());
-
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
         assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getStatus()).isEqualTo(expectedOperationStatus);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModel()).isEqualTo(responseResourceModel);
         assertThat(response.getResourceModels()).isNull();

--- a/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/UpdateHandlerTest.java
+++ b/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/UpdateHandlerTest.java
@@ -7,11 +7,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
+import software.amazon.awssdk.services.redshiftserverless.model.ConflictException;
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupRequest;
+import software.amazon.awssdk.services.redshiftserverless.model.InternalServerException;
 import software.amazon.awssdk.services.redshiftserverless.model.ListTagsForResourceRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.UpdateWorkgroupRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
@@ -74,5 +77,74 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_retryOnConflictException() {
+        final UpdateHandler handler = new UpdateHandler();
+
+        final ResourceModel requestResourceModel = updateRequestResourceModel();
+        final ResourceModel responseResourceModel = getReadResponseResourceModel();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(requestResourceModel)
+                .build();
+
+        ConflictException exception = ConflictException.builder()
+                .message("There is an operation running on the existing workgroup. Try again later.")
+                .build();
+
+        /**
+         * The Thread.sleep() is actually called here, making unit longer.
+         * MockStatic easily will need a Java version upgrade, then the Mockito upgrade,
+         * I'll leave the upgrade in another commit.
+         */
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
+        when(proxyClient.client().updateWorkgroup(any(UpdateWorkgroupRequest.class)))
+                .thenThrow(exception)
+                .thenReturn(updateResponseSdk());
+        when(proxyClient.client().getWorkgroup(any(GetWorkgroupRequest.class))).thenReturn(getReadResponseSdk());
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(responseResourceModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_noRetryOnOtherException() {
+        final UpdateHandler handler = new UpdateHandler();
+        final ResourceModel requestResourceModel = updateResponseResourceModel();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(requestResourceModel)
+                .build();
+
+        /**
+         * The Thread.sleep() is actually called here, making unit longer.
+         * MockStatic easily will need a Java version upgrade, then the Mockito upgrade,
+         * I'll leave the upgrade in another commit.
+         */
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
+                .thenReturn(ListTagsForResourceResponse.builder().build());
+        when(proxyClient.client().updateWorkgroup(any(UpdateWorkgroupRequest.class)))
+                .thenThrow(InternalServerException.builder()
+                        .message("test")
+                        .build());
+        when(proxyClient.client().getWorkgroup(any(GetWorkgroupRequest.class))).thenReturn(getReadResponseSdk());
+
+        final ProgressEvent<ResourceModel, CallbackContext> response =
+                handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo("test");
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InternalFailure);
     }
 }


### PR DESCRIPTION
In eu-north-1 region, some wf steps take longer to finish, and contract test would fail because of ConflictException("There is an operation running on the workgroup") and contract test will fail.

This commit handles the exception by matching the exception message and retry on the exception, giving the wf more time to finish.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
