### PR TITLE
Increase wg busy max retries to 5

### DIFF
--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/CreateHandler.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/CreateHandler.java
@@ -44,7 +44,7 @@ public class CreateHandler extends BaseHandlerStd {
 
     private CreateWorkgroupResponse createWorkgroup(final CreateWorkgroupRequest awsRequest,
                                                     final ProxyClient<RedshiftServerlessClient> proxyClient) {
-        final int MAX_RETRIES = 4;
+        final int MAX_RETRIES = 5;
         int retryCount = 0;
 
         while (true) {

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/UpdateHandler.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/UpdateHandler.java
@@ -179,7 +179,7 @@ public class UpdateHandler extends BaseHandlerStd {
 
     private UpdateWorkgroupResponse updateWorkgroup(final UpdateWorkgroupRequest awsRequest,
                                                     final ProxyClient<RedshiftServerlessClient> proxyClient) {
-        final int MAX_RETRIES = 4;
+        final int MAX_RETRIES = 5;
         int retryCount = 0;
 
         while (true) {


### PR DESCRIPTION
When running tests in prod eu-north-1, we keep running into the same issue that was resolved during local test run. Before we can fix the issue in backend, we'll increase the handler retries to succeed the operation.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
