### PR TITLE
Fix for Workgroup stabilization failures on operations

### DIFF
--- a/aws-redshiftserverless-workgroup/aws-redshiftserverless-workgroup.json
+++ b/aws-redshiftserverless-workgroup/aws-redshiftserverless-workgroup.json
@@ -327,7 +327,8 @@
                 "ec2:DescribeAvailabilityZones",
                 "redshift-serverless:CreateNamespace",
                 "redshift-serverless:CreateWorkgroup",
-                "redshift-serverless:GetWorkgroup"
+                "redshift-serverless:GetWorkgroup",
+                "redshift-serverless:GetNamespace"
             ]
         },
         "read": {
@@ -368,6 +369,7 @@
                 "ec2:DescribeAccountAttributes",
                 "ec2:DescribeAvailabilityZones",
                 "redshift-serverless:GetWorkgroup",
+                "redshift-serverless:GetNamespace",
                 "redshift-serverless:DeleteWorkgroup"
             ]
         },

--- a/aws-redshiftserverless-workgroup/resource-role.yaml
+++ b/aws-redshiftserverless-workgroup/resource-role.yaml
@@ -37,6 +37,7 @@ Resources:
                 - "ec2:DescribeSecurityGroups"
                 - "ec2:DescribeSubnets"
                 - "ec2:DescribeVpcAttribute"
+                - "redshift-serverless:GetNamespace"
                 - "redshift-serverless:CreateNamespace"
                 - "redshift-serverless:CreateWorkgroup"
                 - "redshift-serverless:DeleteWorkgroup"

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/BaseHandlerStd.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/BaseHandlerStd.java
@@ -2,18 +2,31 @@ package software.amazon.redshiftserverless.workgroup;
 
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
 import software.amazon.awssdk.services.redshiftserverless.model.ConflictException;
+import software.amazon.awssdk.services.redshiftserverless.model.CreateWorkgroupRequest;
+import software.amazon.awssdk.services.redshiftserverless.model.CreateWorkgroupResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.DeleteWorkgroupRequest;
+import software.amazon.awssdk.services.redshiftserverless.model.DeleteWorkgroupResponse;
+import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceRequest;
+import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupRequest;
-import software.amazon.awssdk.services.redshiftserverless.model.RedshiftServerlessResponse;
+import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupResponse;
+import software.amazon.awssdk.services.redshiftserverless.model.Namespace;
 import software.amazon.awssdk.services.redshiftserverless.model.ResourceNotFoundException;
-import software.amazon.awssdk.services.redshiftserverless.model.WorkgroupStatus;
+import software.amazon.awssdk.services.redshiftserverless.model.UpdateWorkgroupRequest;
+import software.amazon.awssdk.services.redshiftserverless.model.UpdateWorkgroupResponse;
+import software.amazon.awssdk.services.redshiftserverless.model.ValidationException;
+import software.amazon.awssdk.services.redshiftserverless.model.InternalServerException;
+import software.amazon.awssdk.services.redshiftserverless.model.InsufficientCapacityException;
+import software.amazon.awssdk.services.redshiftserverless.model.TooManyTagsException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.proxy.delay.Constant;
 
+import java.util.regex.Pattern;
 import java.time.Duration;
 
 // Placeholder for the functionality that could be shared across Create/Read/Update/Delete/List Handlers
@@ -23,12 +36,19 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     public static final String BUSY_WORKGROUP_RETRY_EXCEPTION_MESSAGE =
             "There is an operation running on the existing workgroup";
 
+    protected static final String NAMESPACE_STATUS_AVAILABLE = "available";
+
     protected static boolean isRetriableWorkgroupException(ConflictException exception) {
         return exception.getMessage().contains(BUSY_WORKGROUP_RETRY_EXCEPTION_MESSAGE);
     }
 
     protected static final Constant BACKOFF_STRATEGY = Constant.of()
-            .timeout(Duration.ofMinutes(30L))
+            .timeout(Duration.ofMinutes(120L))
+            .delay(Duration.ofSeconds(5L))
+            .build();
+
+    protected static final Constant PREOPERATION_BACKOFF_STRATEGY = Constant.of()
+            .timeout(Duration.ofMinutes(5L))
             .delay(Duration.ofSeconds(5L))
             .build();
 
@@ -38,6 +58,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
             final Logger logger) {
+
         return handleRequest(
                 proxy,
                 request,
@@ -54,28 +75,80 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final ProxyClient<RedshiftServerlessClient> proxyClient,
             final Logger logger);
 
-    public boolean isWorkgroupStable(final Object awsRequest,
-                                     final RedshiftServerlessResponse awsResponse,
-                                     final ProxyClient<RedshiftServerlessClient> proxyClient,
-                                     final ResourceModel model,
-                                     final CallbackContext context) {
-        GetWorkgroupRequest getStatusRequest = GetWorkgroupRequest.builder()
-                .workgroupName(model.getWorkgroupName())
-                .build();
+    protected GetNamespaceResponse readNamespace(final GetNamespaceRequest getNamespaceRequest,
+                                                 final ProxyClient<RedshiftServerlessClient> proxyClient) {
 
-        try {
-            WorkgroupStatus workgroupStatus = proxyClient.injectCredentialsAndInvokeV2(getStatusRequest, proxyClient.client()::getWorkgroup)
-                    .workgroup()
-                    .status();
+        GetNamespaceResponse getNamespaceResponse = proxyClient.injectCredentialsAndInvokeV2(
+                getNamespaceRequest, proxyClient.client()::getNamespace);
 
-            return workgroupStatus.equals(WorkgroupStatus.AVAILABLE) && !(awsRequest instanceof DeleteWorkgroupRequest);
+        return getNamespaceResponse;
+    }
 
-        } catch (ResourceNotFoundException e) {
-            if (awsRequest instanceof DeleteWorkgroupRequest) {
-                return true;
-            } else {
-                throw e;
-            }
+    protected GetWorkgroupResponse readWorkgroup(final GetWorkgroupRequest awsRequest,
+                                                 final ProxyClient<RedshiftServerlessClient> proxyClient) {
+
+        GetWorkgroupResponse awsResponse = proxyClient.injectCredentialsAndInvokeV2(
+                awsRequest, proxyClient.client()::getWorkgroup);
+
+        return awsResponse;
+    }
+
+    protected CreateWorkgroupResponse createWorkgroup(final CreateWorkgroupRequest awsRequest,
+                                                      final ProxyClient<RedshiftServerlessClient> proxyClient) {
+
+        CreateWorkgroupResponse awsResponse = proxyClient.injectCredentialsAndInvokeV2(
+                awsRequest, proxyClient.client()::createWorkgroup);
+
+        return awsResponse;
+    }
+
+    protected UpdateWorkgroupResponse updateWorkgroup(final UpdateWorkgroupRequest awsRequest,
+                                                      final ProxyClient<RedshiftServerlessClient> proxyClient) {
+
+        UpdateWorkgroupResponse awsResponse = proxyClient.injectCredentialsAndInvokeV2(
+                awsRequest, proxyClient.client()::updateWorkgroup);
+
+        return awsResponse;
+
+    }
+
+    protected DeleteWorkgroupResponse deleteWorkgroup(final DeleteWorkgroupRequest awsRequest,
+                                                      final ProxyClient<RedshiftServerlessClient> proxyClient) {
+
+        DeleteWorkgroupResponse awsResponse = proxyClient.injectCredentialsAndInvokeV2(
+                awsRequest, proxyClient.client()::deleteWorkgroup);
+
+        return awsResponse;
+    }
+
+    protected ProgressEvent<ResourceModel, CallbackContext> defaultWorkgroupErrorHandler(final Object awsRequest,
+                                                                                         final Exception exception,
+                                                                                         final ProxyClient<RedshiftServerlessClient> client,
+                                                                                         final ResourceModel model,
+                                                                                         final CallbackContext context) {
+
+        if (exception instanceof ValidationException || exception instanceof TooManyTagsException) {
+            return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.InvalidRequest);
+
+        } else if (exception instanceof ConflictException || exception instanceof InsufficientCapacityException) {
+            Pattern pattern = Pattern.compile(".*already exists.*", Pattern.CASE_INSENSITIVE);
+            HandlerErrorCode handlerErrorCode = pattern.matcher(exception.getMessage()).matches() ?
+                    HandlerErrorCode.AlreadyExists :
+                    HandlerErrorCode.ResourceConflict;
+
+            return ProgressEvent.defaultFailureHandler(exception, handlerErrorCode);
+
+        } else if (exception instanceof ResourceNotFoundException) {
+            return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.NotFound);
+
+        } else if (exception instanceof InternalServerException) {
+            return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.InternalFailure);
+
+        } else if (exception instanceof ValidationException) {
+            return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.InvalidRequest);
+
+        } else {
+            return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.GeneralServiceException);
         }
     }
 }

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/CreateHandler.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/CreateHandler.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupRequ
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceResponse;
+import software.amazon.awssdk.services.redshiftserverless.model.NamespaceStatus;
 import software.amazon.awssdk.services.redshiftserverless.model.WorkgroupStatus;
 import software.amazon.awssdk.services.redshiftserverless.model.InsufficientCapacityException;
 import software.amazon.awssdk.services.redshiftserverless.model.InternalServerException;
@@ -76,7 +77,7 @@ public class CreateHandler extends BaseHandlerStd {
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
     }
 
-    private boolean isWorkgroupStable(final Object awsRequest,
+    private boolean isWorkgroupStable(final CreateWorkgroupRequest awsRequest,
                                       final RedshiftServerlessResponse awsResponse,
                                       final ProxyClient<RedshiftServerlessClient> proxyClient,
                                       final ResourceModel model,
@@ -96,7 +97,7 @@ public class CreateHandler extends BaseHandlerStd {
         return getWorkgroupResponse.workgroup().status().equals(WorkgroupStatus.AVAILABLE);
     }
 
-    private boolean isNamespaceStable(final Object awsRequest,
+    private boolean isNamespaceStable(final GetNamespaceRequest awsRequest,
                                       final RedshiftServerlessResponse awsResponse,
                                       final ProxyClient<RedshiftServerlessClient> proxyClient,
                                       final ResourceModel model,
@@ -113,7 +114,7 @@ public class CreateHandler extends BaseHandlerStd {
 
         logger.log(getNamespaceResponse.toString());
 
-        return NAMESPACE_STATUS_AVAILABLE.equalsIgnoreCase(getNamespaceResponse.namespace().statusAsString());
+        return getNamespaceResponse.namespace().status().equals(NamespaceStatus.AVAILABLE);
     }
 
     private ProgressEvent<ResourceModel, CallbackContext> createWorkgroupErrorHandler(final Object awsRequest,

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/DeleteHandler.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/DeleteHandler.java
@@ -9,6 +9,7 @@ import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceResp
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.InternalServerException;
+import software.amazon.awssdk.services.redshiftserverless.model.NamespaceStatus;
 import software.amazon.awssdk.services.redshiftserverless.model.RedshiftServerlessResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.redshiftserverless.model.ValidationException;
@@ -94,7 +95,7 @@ public class DeleteHandler extends BaseHandlerStd {
         return false;
     }
 
-    private boolean isNamespaceStable(final Object awsRequest,
+    private boolean isNamespaceStable(final GetNamespaceRequest awsRequest,
                                       final RedshiftServerlessResponse awsResponse,
                                       final ProxyClient<RedshiftServerlessClient> proxyClient,
                                       final ResourceModel model,
@@ -111,7 +112,7 @@ public class DeleteHandler extends BaseHandlerStd {
 
         logger.log(getNamespaceResponse.toString());
 
-        return NAMESPACE_STATUS_AVAILABLE.equalsIgnoreCase(getNamespaceResponse.namespace().statusAsString());
+        return getNamespaceResponse.namespace().status().equals(NamespaceStatus.AVAILABLE);
     }
 
     private ProgressEvent<ResourceModel, CallbackContext> deleteWorkgroupErrorHandler(final Object awsRequest,

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/ReadHandler.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/ReadHandler.java
@@ -3,10 +3,6 @@ package software.amazon.redshiftserverless.workgroup;
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupResponse;
-import software.amazon.awssdk.services.redshiftserverless.model.InternalServerException;
-import software.amazon.awssdk.services.redshiftserverless.model.ResourceNotFoundException;
-import software.amazon.awssdk.services.redshiftserverless.model.ValidationException;
-import software.amazon.awssdk.services.redshiftserverless.model.WorkgroupStatus;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -34,62 +30,19 @@ public class ReadHandler extends BaseHandlerStd {
 
         return proxy.initiate("AWS-RedshiftServerless-Workgroup::Read", proxyClient, request.getDesiredResourceState(), callbackContext)
                 .translateToServiceRequest(Translator::translateToReadRequest)
-                .makeServiceCall(this::readWorkgroup)
-                .handleError(this::readWorkgroupErrorHandler)
-                .done(awsResponse -> getProgressEventFromReadWorkgroupResponse(awsResponse, callbackContext));
-    }
+                .makeServiceCall((awsRequest, sdkProxyClient) -> {
+                    GetWorkgroupResponse awsResponse = this.readWorkgroup(awsRequest, sdkProxyClient);
 
-    private GetWorkgroupResponse readWorkgroup(final GetWorkgroupRequest awsRequest,
-                                               final ProxyClient<RedshiftServerlessClient> proxyClient) {
-        GetWorkgroupResponse awsResponse;
-            awsResponse = proxyClient.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::getWorkgroup);
+                    logger.log(String.format("%s : %s has successfully been read.", ResourceModel.TYPE_NAME, awsRequest.workgroupName()));
+                    logger.log(awsResponse.toString());
 
-            logger.log(String.format("%s has successfully been read.", ResourceModel.TYPE_NAME));
-            return awsResponse;
-    }
-
-    /**
-     * We used to return operationStatus.SUCCESS for all workgroup statuses,
-     * including creating, deleting, modifying.
-     *
-     * When CFN contract test checks if the resource has been deleted by calling ReadHandler,
-     * and when the workgroup == DELETING, we should have returned in_progress to indicate the
-     * deletion is not finished, and contract test can't start creating the same resource again.
-     *
-     * Same scenario would cause customer issues too.
-     *
-     * @param getWorkgroupResponse
-     * @param ctx
-     * @return
-     */
-    private static ProgressEvent<ResourceModel, CallbackContext> getProgressEventFromReadWorkgroupResponse(GetWorkgroupResponse getWorkgroupResponse,
-                                                                                                    CallbackContext ctx) {
-        ResourceModel workgroupModel = Translator.translateFromReadResponse(getWorkgroupResponse);
-        List<WorkgroupStatus> inProgressWorkgroupStatuses = Arrays.asList(
-                WorkgroupStatus.CREATING,
-                WorkgroupStatus.DELETING,
-                WorkgroupStatus.MODIFYING
-        );
-        boolean isInProgress = inProgressWorkgroupStatuses.contains(getWorkgroupResponse.workgroup().status());
-
-        ProgressEvent<ResourceModel, CallbackContext> progressEvent = progress(workgroupModel, ctx);
-        progressEvent.setStatus(isInProgress ? OperationStatus.IN_PROGRESS : OperationStatus.SUCCESS);
-        return progressEvent;
-    }
-
-    private ProgressEvent<ResourceModel, CallbackContext> readWorkgroupErrorHandler(final GetWorkgroupRequest awsRequest,
-                                                                                    final Exception exception,
-                                                                                    final ProxyClient<RedshiftServerlessClient> client,
-                                                                                    final ResourceModel model,
-                                                                                    final CallbackContext context) {
-        if (exception instanceof ResourceNotFoundException) {
-            return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.NotFound);
-        } else if (exception instanceof ValidationException) {
-            return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.InvalidRequest);
-        } else if (exception instanceof InternalServerException) {
-            return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.InternalFailure);
-        } else {
-            return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.GeneralServiceException);
-        }
+                    return awsResponse;
+                })
+                .handleError((awsRequest, exception, client, resourceModel, cxt) -> {
+                    logger.log(String.format("Operation: %s : encountered exception for model: %s", awsRequest.getClass().getName(), ResourceModel.TYPE_NAME));
+                    logger.log(awsRequest.toString());
+                    return this.defaultWorkgroupErrorHandler(awsRequest, exception, client, resourceModel, cxt);
+                })
+                .done(awsResponse -> ProgressEvent.defaultSuccessHandler(Translator.translateFromReadResponse(awsResponse)));
     }
 }

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/ReadHandler.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/ReadHandler.java
@@ -17,7 +17,6 @@ import java.util.List;
 import static software.amazon.cloudformation.proxy.ProgressEvent.progress;
 
 public class ReadHandler extends BaseHandlerStd {
-    private Logger logger;
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
@@ -30,14 +29,7 @@ public class ReadHandler extends BaseHandlerStd {
 
         return proxy.initiate("AWS-RedshiftServerless-Workgroup::Read", proxyClient, request.getDesiredResourceState(), callbackContext)
                 .translateToServiceRequest(Translator::translateToReadRequest)
-                .makeServiceCall((awsRequest, sdkProxyClient) -> {
-                    GetWorkgroupResponse awsResponse = this.readWorkgroup(awsRequest, sdkProxyClient);
-
-                    logger.log(String.format("%s : %s has successfully been read.", ResourceModel.TYPE_NAME, awsRequest.workgroupName()));
-                    logger.log(awsResponse.toString());
-
-                    return awsResponse;
-                })
+                .makeServiceCall(this::readWorkgroup)
                 .handleError((awsRequest, exception, client, resourceModel, cxt) -> {
                     logger.log(String.format("Operation: %s : encountered exception for model: %s", awsRequest.getClass().getName(), ResourceModel.TYPE_NAME));
                     logger.log(awsRequest.toString());

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/Translator.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/Translator.java
@@ -3,7 +3,10 @@ package software.amazon.redshiftserverless.workgroup;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import software.amazon.awssdk.services.redshiftserverless.model.CreateWorkgroupRequest;
+import software.amazon.awssdk.services.redshiftserverless.model.CreateWorkgroupResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.DeleteWorkgroupRequest;
+import software.amazon.awssdk.services.redshiftserverless.model.DeleteWorkgroupResponse;
+import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.ListTagsForResourceRequest;
@@ -103,6 +106,40 @@ public class Translator {
     }
 
     /**
+     * Translates resource object from sdk into a resource model
+     *
+     * @param awsResponse the aws service describe resource response
+     * @return model resource model
+     */
+    static ResourceModel translateFromCreateResponse(final CreateWorkgroupResponse awsResponse) {
+        return ResourceModel.builder()
+                .workgroupName(awsResponse.workgroup().workgroupName())
+                .namespaceName(awsResponse.workgroup().namespaceName())
+                .workgroup(Workgroup.builder()
+                        .workgroupName(awsResponse.workgroup().workgroupName())
+                        .namespaceName(awsResponse.workgroup().namespaceName())
+                        .build())
+                .build();
+    }
+
+    /**
+     * Translates resource object from sdk into a resource model
+     *
+     * @param awsResponse the aws service describe resource response
+     * @return model resource model
+     */
+    static ResourceModel translateFromDeleteResponse(final DeleteWorkgroupResponse awsResponse) {
+        return ResourceModel.builder()
+                .workgroupName(awsResponse.workgroup().workgroupName())
+                .namespaceName(awsResponse.workgroup().namespaceName())
+                .workgroup(Workgroup.builder()
+                        .workgroupName(awsResponse.workgroup().workgroupName())
+                        .namespaceName(awsResponse.workgroup().namespaceName())
+                        .build())
+                .build();
+    }
+
+    /**
      * Request to delete a resource
      *
      * @param model resource model
@@ -131,6 +168,17 @@ public class Translator {
                 .subnetIds(model.getSubnetIds())
                 .securityGroupIds(model.getSecurityGroupIds())
                 .port(model.getPort())
+                .build();
+    }
+
+    /**
+     * Request to read a resource
+     * @param model resource model
+     * @return awsRequest the aws service request to describe a resource
+     */
+    static GetNamespaceRequest translateToReadNamespaceRequest(final ResourceModel model) {
+        return GetNamespaceRequest.builder()
+                .namespaceName(model.getNamespaceName())
                 .build();
     }
 

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/UpdateHandler.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/UpdateHandler.java
@@ -33,7 +33,6 @@ import java.util.Set;
 import java.util.function.BiFunction;
 
 public class UpdateHandler extends BaseHandlerStd {
-    private Logger logger;
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
@@ -121,26 +120,6 @@ public class UpdateHandler extends BaseHandlerStd {
                 .port((Integer) getDelta.apply(desiredModel.getPort(), previousModel.getPort()))
                 .workgroup(previousModel.getWorkgroup())
                 .build();
-    }
-
-    private boolean isWorkgroupStable(final Object awsRequest,
-                                      final RedshiftServerlessResponse awsResponse,
-                                      final ProxyClient<RedshiftServerlessClient> proxyClient,
-                                      final ResourceModel model,
-                                      final CallbackContext context) {
-
-        GetWorkgroupRequest getWorkgroupStatusRequest = GetWorkgroupRequest.builder()
-                .workgroupName(model.getWorkgroupName())
-                .build();
-
-        GetWorkgroupResponse getWorkgroupResponse = this.readWorkgroup(getWorkgroupStatusRequest, proxyClient);
-
-        logger.log(String.format("%s : Workgroup: %s has successfully been read.",
-                ResourceModel.TYPE_NAME, getWorkgroupResponse.workgroup().workgroupName()));
-
-        logger.log(getWorkgroupResponse.toString());
-
-        return getWorkgroupResponse.workgroup().status().equals(WorkgroupStatus.AVAILABLE);
     }
 
     private ListTagsForResourceResponse readTags(final ListTagsForResourceRequest awsRequest,

--- a/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/AbstractTestBase.java
+++ b/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/AbstractTestBase.java
@@ -12,6 +12,7 @@ import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceResp
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.ListWorkgroupsResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.UpdateWorkgroupResponse;
+import software.amazon.awssdk.services.redshiftserverless.model.NamespaceStatus;
 import software.amazon.awssdk.services.redshiftserverless.model.WorkgroupStatus;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Credentials;
@@ -36,7 +37,7 @@ public class AbstractTestBase {
     private static final int UPDATED_BASE_CAPACITY;
     private static final int UPDATED_MAX_CAPACITY;
     private static final WorkgroupStatus STATUS;
-    private static final String NAMESPACE_STATUS;
+    private static final NamespaceStatus NAMESPACE_STATUS;
     private static final List<String> SUBNET_IDS;
     private static final List<String> SECURITY_GROUP_IDS;
     private static final Set<ConfigParameter> CONFIG_PARAMETERS;
@@ -50,7 +51,7 @@ public class AbstractTestBase {
 
         WORKGROUP_NAME = "DUMMY_WORKGROUP";
         NAMESPACE_NAME = "DUMMY_NAMESPACE";
-        NAMESPACE_STATUS = "available";
+        NAMESPACE_STATUS = NamespaceStatus.AVAILABLE;
         WORKGROUP_ARN = "DUMMY_WORKGROUP_ARN";
         BASE_CAPACITY = 0;
         UPDATED_BASE_CAPACITY = 0;

--- a/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/AbstractTestBase.java
+++ b/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/AbstractTestBase.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
 import software.amazon.awssdk.services.redshiftserverless.model.CreateWorkgroupResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.DeleteWorkgroupResponse;
+import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.ListWorkgroupsResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.UpdateWorkgroupResponse;
@@ -35,6 +36,7 @@ public class AbstractTestBase {
     private static final int UPDATED_BASE_CAPACITY;
     private static final int UPDATED_MAX_CAPACITY;
     private static final WorkgroupStatus STATUS;
+    private static final String NAMESPACE_STATUS;
     private static final List<String> SUBNET_IDS;
     private static final List<String> SECURITY_GROUP_IDS;
     private static final Set<ConfigParameter> CONFIG_PARAMETERS;
@@ -48,6 +50,7 @@ public class AbstractTestBase {
 
         WORKGROUP_NAME = "DUMMY_WORKGROUP";
         NAMESPACE_NAME = "DUMMY_NAMESPACE";
+        NAMESPACE_STATUS = "available";
         WORKGROUP_ARN = "DUMMY_WORKGROUP_ARN";
         BASE_CAPACITY = 0;
         UPDATED_BASE_CAPACITY = 0;
@@ -138,6 +141,16 @@ public class AbstractTestBase {
                 .build();
     }
 
+    public static GetNamespaceResponse getNamespaceResponseSdk() {
+        return GetNamespaceResponse.builder()
+                .namespace(
+                        software.amazon.awssdk.services.redshiftserverless.model.Namespace.builder()
+                                .status(NAMESPACE_STATUS)
+                                .namespaceName(NAMESPACE_NAME)
+                                .build())
+                .build();
+    }
+
     public static GetWorkgroupResponse getReadResponseSdk() {
         return GetWorkgroupResponse.builder()
                 .workgroup(software.amazon.awssdk.services.redshiftserverless.model.Workgroup.builder()
@@ -150,7 +163,6 @@ public class AbstractTestBase {
                         .securityGroupIds(SECURITY_GROUP_IDS)
                         .subnetIds(SUBNET_IDS)
                         .configParameters(RESPONSE_CONFIG_PARAMS)
-                        .creationDate(null)
                         .publiclyAccessible(true)
                         .endpoint(software.amazon.awssdk.services.redshiftserverless.model.Endpoint.builder()
                                 .port(DEFAULT_PORT)
@@ -167,7 +179,10 @@ public class AbstractTestBase {
     }
 
     public static DeleteWorkgroupResponse deleteResponseSdk() {
-        return DeleteWorkgroupResponse.builder().build();
+        return DeleteWorkgroupResponse.builder()
+                .workgroup(software.amazon.awssdk.services.redshiftserverless.model.Workgroup.builder()
+                        .workgroupName(WORKGROUP_NAME)
+                        .build()).build();
     }
 
     public static ResourceModel listRequestResourceModel() {

--- a/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/CreateHandlerTest.java
+++ b/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/CreateHandlerTest.java
@@ -7,12 +7,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
-import software.amazon.awssdk.services.redshiftserverless.model.ConflictException;
 import software.amazon.awssdk.services.redshiftserverless.model.CreateWorkgroupRequest;
+import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupRequest;
-import software.amazon.awssdk.services.redshiftserverless.model.InternalServerException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
@@ -64,6 +62,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         when(proxyClient.client().createWorkgroup(any(CreateWorkgroupRequest.class))).thenReturn(createResponseSdk());
         when(proxyClient.client().getWorkgroup(any(GetWorkgroupRequest.class))).thenReturn(getReadResponseSdk());
+        when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
 
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -74,70 +73,5 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
-    }
-
-    @Test
-    public void handleRequest_retryOnConflictException() {
-        final CreateHandler handler = new CreateHandler();
-
-        final ResourceModel requestResourceModel = createRequestResourceModel();
-        final ResourceModel responseResourceModel = getReadResponseResourceModel();
-
-        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .desiredResourceState(requestResourceModel)
-                .build();
-
-        ConflictException exception = ConflictException.builder()
-                .message("There is an operation running on the existing workgroup. Try again later.")
-                .build();
-
-        /**
-         * The Thread.sleep() is actually called here, making unit longer.
-         * MockStatic easily will need a Java version upgrade, then the Mockito upgrade,
-         * I'll leave the upgrade in another commit.
-         */
-        when(proxyClient.client().createWorkgroup(any(CreateWorkgroupRequest.class)))
-                .thenThrow(exception)
-                .thenReturn(createResponseSdk());
-        when(proxyClient.client().getWorkgroup(any(GetWorkgroupRequest.class))).thenReturn(getReadResponseSdk());
-
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(responseResourceModel);
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
-    }
-
-    @Test
-    public void handleRequest_noRetryOnOtherException() throws InterruptedException {
-        final CreateHandler handler = new CreateHandler();
-        final ResourceModel requestResourceModel = createRequestResourceModel();
-        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .desiredResourceState(requestResourceModel)
-                .build();
-
-        /**
-         * The Thread.sleep() is actually called here, making unit longer.
-         * MockStatic easily will need a Java version upgrade, then the Mockito upgrade,
-         * I'll leave the upgrade in another commit.
-         */
-        when(proxyClient.client().createWorkgroup(any(CreateWorkgroupRequest.class)))
-                .thenThrow(InternalServerException.builder()
-                        .message("test")
-                        .build());
-
-        final ProgressEvent<ResourceModel, CallbackContext> response =
-                handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isEqualTo("test");
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InternalFailure);
     }
 }

--- a/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/DeleteHandlerTest.java
+++ b/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/DeleteHandlerTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
 import software.amazon.awssdk.services.redshiftserverless.model.DeleteWorkgroupRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupRequest;
+import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.ResourceNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
@@ -22,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -60,7 +62,12 @@ public class DeleteHandlerTest extends AbstractTestBase {
                 .build();
 
         when(proxyClient.client().deleteWorkgroup(any(DeleteWorkgroupRequest.class))).thenReturn(deleteResponseSdk());
-        when(proxyClient.client().getWorkgroup(any(GetWorkgroupRequest.class))).thenThrow(ResourceNotFoundException.class);
+        // We first retreive workgroup, then wait for workgroup to be in available state and then get workgroup after delete operation
+        when(proxyClient.client().getWorkgroup(any(GetWorkgroupRequest.class)))
+                .thenThrow(ResourceNotFoundException.builder().build());
+
+        when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
+
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
         assertThat(response).isNotNull();

--- a/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/DeleteHandlerTest.java
+++ b/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/DeleteHandlerTest.java
@@ -65,9 +65,7 @@ public class DeleteHandlerTest extends AbstractTestBase {
         // We first retreive workgroup, then wait for workgroup to be in available state and then get workgroup after delete operation
         when(proxyClient.client().getWorkgroup(any(GetWorkgroupRequest.class)))
                 .thenThrow(ResourceNotFoundException.builder().build());
-
-        when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
-
+        
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
         assertThat(response).isNotNull();

--- a/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/ReadHandlerTest.java
+++ b/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/ReadHandlerTest.java
@@ -4,33 +4,23 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
-import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupRequest;
-import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupResponse;
-import software.amazon.awssdk.services.redshiftserverless.model.WorkgroupStatus;
-import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
-import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.lang.reflect.Method;
 import java.time.Duration;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -58,41 +48,24 @@ public class ReadHandlerTest extends AbstractTestBase {
         verifyNoMoreInteractions(sdkClient);
     }
 
-    static Stream<Arguments> provideReadHandlerParams() {
-        return Stream.of(
-                Arguments.of(WorkgroupStatus.AVAILABLE, OperationStatus.SUCCESS),
-                Arguments.of(WorkgroupStatus.CREATING, OperationStatus.IN_PROGRESS),
-                Arguments.of(WorkgroupStatus.DELETING, OperationStatus.IN_PROGRESS),
-                Arguments.of(WorkgroupStatus.MODIFYING, OperationStatus.IN_PROGRESS),
-                Arguments.of(WorkgroupStatus.UNKNOWN_TO_SDK_VERSION, OperationStatus.SUCCESS)
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("provideReadHandlerParams")
-    public void handleRequest_callReturns(
-            WorkgroupStatus returnedWgStatus,
-            OperationStatus expectedOperationStatus
-    ) {
+    @Test
+    public void handleRequest_SimpleSuccess() {
         final ReadHandler handler = new ReadHandler();
 
-        GetWorkgroupResponse defaultResponse = getReadResponseSdk();
-        GetWorkgroupResponse testResponse = defaultResponse.toBuilder()
-                .workgroup(defaultResponse.workgroup().toBuilder().status(returnedWgStatus).build())
-                .build();
-
-        when(proxyClient.client().getWorkgroup(any(GetWorkgroupRequest.class))).thenReturn(testResponse);
-
         final ResourceModel requestResourceModel = getReadRequestResourceModel();
-        final ResourceModel responseResourceModel = Translator.translateFromReadResponse(testResponse);
+        final ResourceModel responseResourceModel = getReadResponseResourceModel();
+
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(requestResourceModel)
                 .build();
 
+        when(proxyClient.client().getWorkgroup(any(GetWorkgroupRequest.class))).thenReturn(getReadResponseSdk());
+
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
+        verify(proxyClient.client(), times(1)).getWorkgroup(any(GetWorkgroupRequest.class));
         assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(expectedOperationStatus);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModel()).isEqualTo(responseResourceModel);
         assertThat(response.getResourceModels()).isNull();

--- a/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/UpdateHandlerTest.java
+++ b/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/UpdateHandlerTest.java
@@ -7,14 +7,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
-import software.amazon.awssdk.services.redshiftserverless.model.ConflictException;
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupRequest;
-import software.amazon.awssdk.services.redshiftserverless.model.InternalServerException;
+import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.ListTagsForResourceRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.UpdateWorkgroupRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
@@ -77,74 +75,5 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
-    }
-
-    @Test
-    public void handleRequest_retryOnConflictException() {
-        final UpdateHandler handler = new UpdateHandler();
-
-        final ResourceModel requestResourceModel = updateRequestResourceModel();
-        final ResourceModel responseResourceModel = getReadResponseResourceModel();
-
-        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .desiredResourceState(requestResourceModel)
-                .build();
-
-        ConflictException exception = ConflictException.builder()
-                .message("There is an operation running on the existing workgroup. Try again later.")
-                .build();
-
-        /**
-         * The Thread.sleep() is actually called here, making unit longer.
-         * MockStatic easily will need a Java version upgrade, then the Mockito upgrade,
-         * I'll leave the upgrade in another commit.
-         */
-        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
-        when(proxyClient.client().updateWorkgroup(any(UpdateWorkgroupRequest.class)))
-                .thenThrow(exception)
-                .thenReturn(updateResponseSdk());
-        when(proxyClient.client().getWorkgroup(any(GetWorkgroupRequest.class))).thenReturn(getReadResponseSdk());
-
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(responseResourceModel);
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
-    }
-
-    @Test
-    public void handleRequest_noRetryOnOtherException() {
-        final UpdateHandler handler = new UpdateHandler();
-        final ResourceModel requestResourceModel = updateResponseResourceModel();
-        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .desiredResourceState(requestResourceModel)
-                .build();
-
-        /**
-         * The Thread.sleep() is actually called here, making unit longer.
-         * MockStatic easily will need a Java version upgrade, then the Mockito upgrade,
-         * I'll leave the upgrade in another commit.
-         */
-        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
-                .thenReturn(ListTagsForResourceResponse.builder().build());
-        when(proxyClient.client().updateWorkgroup(any(UpdateWorkgroupRequest.class)))
-                .thenThrow(InternalServerException.builder()
-                        .message("test")
-                        .build());
-        when(proxyClient.client().getWorkgroup(any(GetWorkgroupRequest.class))).thenReturn(getReadResponseSdk());
-
-        final ProgressEvent<ResourceModel, CallbackContext> response =
-                handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isEqualTo("test");
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InternalFailure);
     }
 }


### PR DESCRIPTION
Description: This CR contains fix for stabilization not correctly implemented for Workgroup Resource. During Read handler we are returing in Progress status which is not allowed. This CR will fix that issue.

Currently as part of create and delete handlers we are only checking if Workgroup is stablized. This is causing failures if the same workgroup is created immediately causing "Operation in progress failure". This is because Namespace is not stabilized during the operation. This CR fixes that issue as well.

Testing:
1. Tested if CTV2 is passing in eu-north-1 and us-west-1 region which are currently failing CTV2 for Workgroup resource.
2. Verified CTV2 is passing for those regions in personal account.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
