### PR TITLE
Added a 10sec delay in delete handler to help with stabilization of secret deletion

### DIFF
--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/DeleteHandler.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/DeleteHandler.java
@@ -32,6 +32,14 @@ public class DeleteHandler extends BaseHandlerStd {
                             .handleError(this::defaultErrorHandler)
                             .done(deleteNamespaceResponse -> {
                                 logger.log(String.format("%s %s deleted.",ResourceModel.TYPE_NAME, model.getNamespaceName()));
+                                // TODO: Need to add a stabilize operation to verify if secret is deleted
+                                // This is a temporary fix to handle deletion of secrets for managed passwords
+                                // Since deletion of secret is handled async CTv2 is failing even in SingleTestMode
+                                try {
+                                    Thread.sleep(10000);
+                                } catch(InterruptedException ex) {
+                                    Thread.currentThread().interrupt();
+                                }
                                 return ProgressEvent.defaultSuccessHandler(null);
                             })
                 );


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Contract tests are failing for Namespace because we get the error "Unable to update admin credentials: Unable to create secret for the dbInstance because a secret with a matching name exists". This is happening because delete namespace performs a delete secret operation when managed passwords is called causing the secret to be deleted asynchronously.

As part of CTV2 as these tests use the same cluster identifier it causes the creation of secret with same name in the subsequent test even before the secret can get deleted completed in previous test. This delay is added as a temporary fix to stabilize the operation until the permanent fix to stabilize the operation based on the secret operation is done 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
