### PR TITLE
Modified the wait after delete to be 30secs from 10 secs

### DIFF
--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/DeleteHandler.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/DeleteHandler.java
@@ -36,7 +36,7 @@ public class DeleteHandler extends BaseHandlerStd {
                                 // This is a temporary fix to handle deletion of secrets for managed passwords
                                 // Since deletion of secret is handled async CTv2 is failing even in SingleTestMode
                                 try {
-                                    Thread.sleep(10000);
+                                    Thread.sleep(30000);
                                 } catch(InterruptedException ex) {
                                     Thread.currentThread().interrupt();
                                 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We are changing the wait time after delete to 30secs as Ctv2 was still failing in few regions with secret already exists.
As part of CTv2 CFN runs tests which use the same cluster identifier. Managed passwords uses this identifier to create secrets and reusing the same identifier in tests back to back causes resource conflict exception

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
