### PR TITLE
Fix for delete handler eventual consistency

### DIFF
--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/DeleteHandler.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/DeleteHandler.java
@@ -36,7 +36,7 @@ public class DeleteHandler extends BaseHandlerStd {
                                 // This is a temporary fix to handle deletion of secrets for managed passwords
                                 // Since deletion of secret is handled async CTv2 is failing even in SingleTestMode
                                 try {
-                                    Thread.sleep(10000);
+                                    Thread.sleep(30000);
                                 } catch(InterruptedException ex) {
                                     Thread.currentThread().interrupt();
                                 }

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/BaseHandlerStd.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/BaseHandlerStd.java
@@ -40,6 +40,10 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     public static final String BUSY_WORKGROUP_RETRY_EXCEPTION_MESSAGE =
             "There is an operation running on the existing workgroup";
 
+    // This is for delete workgroup operation. We need AdminWF to finish the operation completely
+    // This is needed for CTV2 to work
+    public static final int EVENTUAL_CONSISTENCY_DELAY_SECONDS = 300;
+
     protected static boolean isRetriableWorkgroupException(ConflictException exception) {
         return exception.getMessage().contains(BUSY_WORKGROUP_RETRY_EXCEPTION_MESSAGE);
     }

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/CallbackContext.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/CallbackContext.java
@@ -8,4 +8,5 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext {
     int retryOnResourceNotFound = 5;
+    boolean propagationDelay = false;
 }

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/DeleteHandler.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/DeleteHandler.java
@@ -42,6 +42,16 @@ public class DeleteHandler extends BaseHandlerStd {
                                     return ProgressEvent.progress(Translator.translateFromDeleteResponse(awsResponse), callbackContext);
                                 })
                 )
+                .then(progress -> {
+                    if (progress.getCallbackContext().isPropagationDelay()) {
+                        logger.log("Propagation delay completed");
+                        return ProgressEvent.progress(progress.getResourceModel(), progress.getCallbackContext());
+                    }
+                    progress.getCallbackContext().setPropagationDelay(true);
+                    logger.log("Setting propagation delay");
+                    return ProgressEvent.defaultInProgressHandler(progress.getCallbackContext(),
+                            EVENTUAL_CONSISTENCY_DELAY_SECONDS, progress.getResourceModel());
+                })
                 .then(progress ->
                         proxy.initiate("AWS-RedshiftServerless-Workgroup::ReadNameSpaceAfterDelete", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
                                 .translateToServiceRequest(Translator::translateToReadNamespaceRequest)

--- a/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/DeleteHandlerTest.java
+++ b/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/DeleteHandlerTest.java
@@ -70,11 +70,21 @@ public class DeleteHandlerTest extends AbstractTestBase {
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
         assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isNull();
-        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(300);
+        assertThat(response.getResourceModel()).isNotNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response2 =
+                handler.handleRequest(proxy, request,response.getCallbackContext(), proxyClient, logger);
+
+        assertThat(response2).isNotNull();
+        assertThat(response2.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response2.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response2.getResourceModel()).isNull();
+        assertThat(response2.getResourceModels()).isNull();
+        assertThat(response2.getMessage()).isNull();
+        assertThat(response2.getErrorCode()).isNull();
     }
 }


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Uluru framework provides an option of introducing delays in operation through eventual consistency model. This gives an option to run the operation with an option to progress after a certain delay for operations that are eventually consistent. This pull request contains changes for the above feature. This is needed as CTv2 tests were failing with operation in progress failure on workgroup. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
