### PR TITLE
Wait for secret deletion in the stabilize operation of namespace delete handler

### DIFF
--- a/aws-redshiftserverless-namespace/.rpdk-config
+++ b/aws-redshiftserverless-namespace/.rpdk-config
@@ -20,5 +20,6 @@
         ],
         "codegen_template_path": "guided_aws",
         "protocolVersion": "2.0.0"
-    }
+    },
+    "executableEntrypoint": "software.amazon.redshiftserverless.namespace.HandlerWrapperExecutable"
 }

--- a/aws-redshiftserverless-namespace/README.md
+++ b/aws-redshiftserverless-namespace/README.md
@@ -31,7 +31,7 @@ The code uses [Lombok](https://projectlombok.org/), and [you may have to install
 ## Note: This should be tested in the same region as your deployed resource.
 ## This would just test the resource handler changes and deploy resource in your account. This uses your local aws credentials
 ## The permissions provided here doesn't truly represent the necessary permission defined in the schema and need to be updated before you execute contract tests.
-## References: 
+## References:
 ##    - https://w.amazon.com/bin/view/AWS21/Design/Uluru/Onboarding_Guide/Uluru_OpenSource_And_Developing_In_Amazon/IntegrationTests/
 
 1. cd <resource_folder> && source <virtualenvfolder>/bin/activate && sam local start-lambda
@@ -51,7 +51,7 @@ The code uses [Lombok](https://projectlombok.org/), and [you may have to install
 ## References:
 ##    - https://docs.aws.amazon.com/cli/latest/reference/cloudformation/create-stack.html
 
-1. cp <resource_folder>/local-test-artifacts/create-<resource>.yaml cp local-test-artifacts/create-<resource>-<feature>.json 
+1. cp <resource_folder>/local-test-artifacts/create-<resource>.yaml cp local-test-artifacts/create-<resource>-<feature>.json
 2. cd <resource_folder> && aws cloudformation create-stack --stack-name <stack-name> --template-body file://local-test-artifacts/create-<resource>-<feature>.yaml> --region <region>
 3. Verify if the cloudformation template is deployed successfully into your account.
 

--- a/aws-redshiftserverless-namespace/docs/namespace.md
+++ b/aws-redshiftserverless-namespace/docs/namespace.md
@@ -37,4 +37,3 @@ _Required_: No
 _Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-redshiftserverless-namespace/docs/tag.md
+++ b/aws-redshiftserverless-namespace/docs/tag.md
@@ -43,4 +43,3 @@ _Type_: String
 _Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-redshiftserverless-namespace/pom.xml
+++ b/aws-redshiftserverless-namespace/pom.xml
@@ -43,6 +43,12 @@
             <artifactId>redshift</artifactId>
             <version>2.22.5</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/secretsmanager -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>secretsmanager</artifactId>
+            <version>2.22.5</version>
+        </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-core</artifactId>

--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/CallbackContext.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/CallbackContext.java
@@ -9,6 +9,7 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 public class CallbackContext extends StdCallbackContext {
     String namespaceArn = null;
     boolean callBackForDelete = false;
+    String adminPasswordSecretArn = null;
 
     public void setNamespaceArn(String namespaceArn) {this.namespaceArn = namespaceArn; }
 
@@ -20,5 +21,13 @@ public class CallbackContext extends StdCallbackContext {
 
     public boolean getCallBackForDelete() {
         return callBackForDelete;
+    }
+
+    public String getAdminPasswordSecretArn() {
+        return adminPasswordSecretArn;
+    }
+
+    public void setAdminPasswordSecretArn(String adminPasswordSecretArn) {
+        this.adminPasswordSecretArn = adminPasswordSecretArn;
     }
 }

--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/ClientBuilder.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/ClientBuilder.java
@@ -2,6 +2,7 @@ package software.amazon.redshiftserverless.namespace;
 
 import software.amazon.awssdk.services.redshift.RedshiftClient;
 import software.amazon.awssdk.services.redshiftserverless.RedshiftServerlessClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.cloudformation.LambdaWrapper;
 
 import java.util.function.Supplier;
@@ -15,6 +16,11 @@ public class ClientBuilder {
   }
     public static RedshiftClient redshiftClient() {
         return RedshiftClient.builder()
+                .httpClient(LambdaWrapper.HTTP_CLIENT)
+                .build();
+    }
+    public static SecretsManagerClient secretsManagerClient() {
+        return SecretsManagerClient.builder()
                 .httpClient(LambdaWrapper.HTTP_CLIENT)
                 .build();
     }

--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/CreateHandler.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/CreateHandler.java
@@ -20,6 +20,7 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -32,6 +33,7 @@ public class CreateHandler extends BaseHandlerStd {
         final CallbackContext callbackContext,
         final ProxyClient<RedshiftServerlessClient> proxyClient,
         final ProxyClient<RedshiftClient> redshiftProxyClient,
+        final ProxyClient<SecretsManagerClient> secretsManagerProxyClient,
         final Logger logger) {
 
         this.logger = logger;
@@ -68,7 +70,7 @@ public class CreateHandler extends BaseHandlerStd {
                return progress;
             })
             .then(progress ->
-                new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, redshiftProxyClient, logger)
+                new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger)
             );
     }
 

--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/ReadHandler.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/ReadHandler.java
@@ -16,6 +16,7 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 public class ReadHandler extends BaseHandlerStd {
     private final String GET_RESOURCE_POLICY_ERROR = "not authorized to perform: redshift:GetResourcePolicy";
@@ -31,6 +32,7 @@ public class ReadHandler extends BaseHandlerStd {
         final CallbackContext callbackContext,
         final ProxyClient<RedshiftServerlessClient> proxyClient,
         final ProxyClient<RedshiftClient> redshiftProxyClient,
+        final ProxyClient<SecretsManagerClient> secretsManagerProxyClient,
         final Logger logger) {
 
         this.logger = logger;

--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/UpdateHandler.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/UpdateHandler.java
@@ -31,6 +31,7 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -48,6 +49,7 @@ public class UpdateHandler extends BaseHandlerStd {
         final CallbackContext callbackContext,
         final ProxyClient<RedshiftServerlessClient> proxyClient,
         final ProxyClient<RedshiftClient> redshiftProxyClient,
+        final ProxyClient<SecretsManagerClient> secretsManagerProxyClient,
         final Logger logger) {
 
         this.logger = logger;
@@ -180,7 +182,7 @@ public class UpdateHandler extends BaseHandlerStd {
 
                     return progress;
                 })
-                .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, redshiftProxyClient, logger));
+                .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger));
     }
 
     private UpdateNamespaceResponse updateNamespace(final UpdateNamespaceRequest updateNamespaceRequest,

--- a/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/CreateHandlerTest.java
+++ b/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/CreateHandlerTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -44,6 +45,9 @@ public class CreateHandlerTest extends AbstractTestBase {
 
     @Mock
     private ProxyClient<RedshiftClient> redshiftProxyClient;
+
+    @Mock
+    private ProxyClient<SecretsManagerClient> secretsManagerProxyClient;
 
     @Mock
     RedshiftClient redshiftSdkClient;
@@ -79,7 +83,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class))).thenReturn(getSnapshotCopyConfigurationsResponseSdk());
         when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -109,7 +113,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         when(redshiftProxyClient.client().putResourcePolicy(any(PutResourcePolicyRequest.class))).thenReturn(putResourcePolicyResponseSdk());
         when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getResourcePolicyResponseSdk());
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -136,7 +140,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class))).thenReturn(getSnapshotCopyConfigurationsResponseSdk());
         when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -189,7 +193,7 @@ public class CreateHandlerTest extends AbstractTestBase {
                         .build());
         when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger);
 
         verify(proxyClient.client(), times(1)).createSnapshotCopyConfiguration(any(CreateSnapshotCopyConfigurationRequest.class));
         assertThat(response).isNotNull();

--- a/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/ReadHandlerTest.java
+++ b/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/ReadHandlerTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.times;
@@ -61,6 +62,9 @@ public class ReadHandlerTest extends AbstractTestBase {
 
     @Mock
     private ProxyClient<RedshiftClient> redshiftProxyClient;
+
+    @Mock
+    private ProxyClient<SecretsManagerClient> secretsManagerProxyClient;
 
     @Mock
     RedshiftClient redshiftSdkClient;
@@ -96,7 +100,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
         when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -153,7 +157,7 @@ public class ReadHandlerTest extends AbstractTestBase {
 
         if (expectedException == null) {
             when(proxyClient.client().listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class))).thenReturn(getSnapshotCopyConfigurationsResponseSdk());
-            final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
+            final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger);
             assertThat(response).isNotNull();
             assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
             assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
@@ -162,7 +166,7 @@ public class ReadHandlerTest extends AbstractTestBase {
             assertThat(response.getMessage()).isNull();
             assertThat(response.getErrorCode()).isNull();
         } else {
-            assertThrows(expectedException, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger));
+            assertThrows(expectedException, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger));
         }
     }
 
@@ -184,7 +188,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
         when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getResourcePolicyResponseSdk());
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -226,7 +230,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
         when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger);
 
         verify(proxyClient.client(), times(1)).listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class));
         assertThat(response).isNotNull();
@@ -276,7 +280,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
         when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger);
         assertThat(response).isNotNull();
         if (expectedErrorCode == null) {
             assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);

--- a/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/UpdateHandlerTest.java
+++ b/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/UpdateHandlerTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -52,6 +53,9 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
     @Mock
     private ProxyClient<RedshiftClient> redshiftProxyClient;
+
+    @Mock
+    private ProxyClient<SecretsManagerClient> secretsManagerProxyClient;
 
     @Mock
     RedshiftClient redshiftSdkClient;
@@ -93,7 +97,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
         when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger);
         verify(proxyClient.client()).updateNamespace(any(UpdateNamespaceRequest.class));
         verify(proxyClient.client(), times(2)).listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class));
         assertThat(response).isNotNull();
@@ -128,7 +132,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
         when(redshiftProxyClient.client().deleteResourcePolicy(any(DeleteResourcePolicyRequest.class))).thenReturn(null);
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -174,7 +178,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .resourcePolicy(newResourcePolicy)
                 .build());
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -205,7 +209,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdkForManagedAdminPasswords());
         when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger);
         verify(proxyClient.client()).updateNamespace(any(UpdateNamespaceRequest.class));
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -242,7 +246,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
         when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger);
         verify(proxyClient.client()).updateNamespace(any(UpdateNamespaceRequest.class));
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -281,7 +285,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdkForManagedAdminPasswords());
         when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger);
         verify(proxyClient.client()).updateNamespace(any(UpdateNamespaceRequest.class));
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -359,7 +363,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
         when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger);
         verify(proxyClient.client()).updateNamespace(any(UpdateNamespaceRequest.class));
         verify(proxyClient.client(), times(1)).deleteSnapshotCopyConfiguration(any(DeleteSnapshotCopyConfigurationRequest.class));
         verify(proxyClient.client(), times(1)).createSnapshotCopyConfiguration(any(CreateSnapshotCopyConfigurationRequest.class));
@@ -426,7 +430,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
         when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, redshiftProxyClient, secretsManagerProxyClient, logger);
         verify(proxyClient.client()).updateNamespace(any(UpdateNamespaceRequest.class));
         verify(proxyClient.client(), times(1)).updateSnapshotCopyConfiguration(any(UpdateSnapshotCopyConfigurationRequest.class));
         verify(proxyClient.client(), times(2)).listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class));

--- a/aws-redshiftserverless-namespace/template.yml
+++ b/aws-redshiftserverless-namespace/template.yml
@@ -13,11 +13,11 @@ Resources:
     Properties:
       Handler: software.amazon.redshiftserverless.namespace.HandlerWrapper::handleRequest
       Runtime: java17
-      CodeUri: ./target/aws-redshiftserverless-namespace-1.0.jar
+      CodeUri: ./target/aws-redshiftserverless-namespace-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshiftserverless.namespace.HandlerWrapper::testEntrypoint
       Runtime: java17
-      CodeUri: ./target/aws-redshiftserverless-namespace-1.0.jar
+      CodeUri: ./target/aws-redshiftserverless-namespace-handler-1.0-SNAPSHOT.jar

--- a/aws-redshiftserverless-workgroup/docs/README.md
+++ b/aws-redshiftserverless-workgroup/docs/README.md
@@ -276,4 +276,3 @@ Returns the <code>PubliclyAccessible</code> value.
 #### CreationDate
 
 Returns the <code>CreationDate</code> value.
-

--- a/aws-redshiftserverless-workgroup/docs/configparameter.md
+++ b/aws-redshiftserverless-workgroup/docs/configparameter.md
@@ -41,4 +41,3 @@ _Type_: String
 _Maximum Length_: <code>15000</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-redshiftserverless-workgroup/docs/tag.md
+++ b/aws-redshiftserverless-workgroup/docs/tag.md
@@ -43,4 +43,3 @@ _Type_: String
 _Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-redshiftserverless-workgroup/docs/workgroup.md
+++ b/aws-redshiftserverless-workgroup/docs/workgroup.md
@@ -38,4 +38,3 @@ _Required_: No
 _Type_: <a href="endpoint.md">Endpoint</a>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/DeleteHandlerTest.java
+++ b/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/DeleteHandlerTest.java
@@ -66,7 +66,7 @@ public class DeleteHandlerTest extends AbstractTestBase {
         when(proxyClient.client().getWorkgroup(any(GetWorkgroupRequest.class)))
                 .thenThrow(ResourceNotFoundException.builder().build());
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
-        
+
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
         assertThat(response).isNotNull();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Remove 30 seconds wait after namespace deletion in namespace delete handler 
- Add secrets manager dependency and client
- Modify the stabilize operation for namespace delete handler to verify that the secret associated with the namespace is deleted 

[Testing]
- Unit Tests
- Manually tested that deletion of following namespaces followed expected behaviour
    - Namespace without secret -> Deleted successfully
    - Namespace with secret and default key -> Deleted successfully
    - Namespace with secret and customer managed key -> Deleted successfully
    - Above three cases with workgroup attached. Delete workgroup and then namespace -> Deleted successfully 
    - Invalid Namespace -> Returns NotFound Error


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
