### PR TITLE
Mapped ThrottlingException to HandlerErrorCode.Throttling

### DIFF
--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/BaseHandlerStd.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/BaseHandlerStd.java
@@ -13,6 +13,7 @@ import software.amazon.awssdk.services.redshiftserverless.model.ListSnapshotCopy
 import software.amazon.awssdk.services.redshiftserverless.model.ServiceQuotaExceededException;
 import software.amazon.awssdk.services.redshiftserverless.model.Namespace;
 import software.amazon.awssdk.services.redshiftserverless.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.redshiftserverless.model.ThrottlingException;
 import software.amazon.awssdk.services.redshiftserverless.model.TooManyTagsException;
 import software.amazon.awssdk.services.redshiftserverless.model.ValidationException;
 import software.amazon.awssdk.services.redshift.RedshiftClient;
@@ -148,6 +149,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
       return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.ServiceInternalError);
     } else if (exception instanceof ResourceNotFoundException) {
       return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.NotFound);
+    } else if (exception instanceof ThrottlingException) {
+      return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.Throttling);
     } else if (exception instanceof TooManyTagsException || exception instanceof ServiceQuotaExceededException) {
       return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.ServiceLimitExceeded);
     } else if (exception instanceof ConflictException) {

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/BaseHandlerStd.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/BaseHandlerStd.java
@@ -12,6 +12,7 @@ import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupRequ
 import software.amazon.awssdk.services.redshiftserverless.model.GetWorkgroupResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.Namespace;
 import software.amazon.awssdk.services.redshiftserverless.model.NamespaceStatus;
+import software.amazon.awssdk.services.redshiftserverless.model.ThrottlingException;
 import software.amazon.awssdk.services.redshiftserverless.model.WorkgroupStatus;
 import software.amazon.awssdk.services.redshiftserverless.model.RedshiftServerlessResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.ResourceNotFoundException;
@@ -230,6 +231,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
         } else if (exception instanceof ValidationException) {
             return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.InvalidRequest);
+
+        } else if (exception instanceof ThrottlingException) {
+            return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.Throttling);
 
         } else {
             return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.GeneralServiceException);


### PR DESCRIPTION
### Description

Mapped `ThrottlingException` to `HandlerErrorCode.Throttling` so that it is (hopefully) automatically retried. Right now `ThrottlingException` is being mapped to `HandlerErrorCode.GeneralServiceException`, which is not retried.

I received this failure when creating a new Redshift Serverless Workgroup with CloudFormation, and from what I can see in CloudTrail, the `CreateWorkgroup` call was only attempted once.

### Documentation

https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/3b91e1187d5d7b15d337a9403ec327edc4cbb1b3/src/main/java/software/amazon/cloudformation/proxy/HandlerErrorCode.java

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
