### PR TITLE
Fix for Update Operation to update tags Support for Namespace

### DIFF
--- a/aws-redshiftserverless-namespace/aws-redshiftserverless-namespace.json
+++ b/aws-redshiftserverless-namespace/aws-redshiftserverless-namespace.json
@@ -225,7 +225,16 @@
         }
     },
     "tagging": {
-        "taggable": false
+        "taggable": true,
+        "tagOnCreate": true,
+        "tagUpdatable": true,
+        "cloudFormationSystemTags": false,
+        "tagProperty": "/properties/Tags",
+        "permissions": [
+            "redshift-serverless:ListTagsForResource",
+            "redshift-serverless:TagResource",
+            "redshift-serverless:UntagResource"
+        ]
     },
     "required": [
         "NamespaceName"
@@ -248,9 +257,6 @@
         "/properties/AdminUserPassword",
         "/properties/FinalSnapshotName",
         "/properties/FinalSnapshotRetentionPeriod",
-        "/properties/Tags",
-        "/properties/Tags/*/Key",
-        "/properties/Tags/*/Value",
         "/properties/ManageAdminPassword",
         "/properties/RedshiftIdcApplicationArn"
     ],
@@ -264,6 +270,7 @@
     "handlers": {
         "create": {
             "permissions": [
+                "iam:CreateServiceLinkedRole",
                 "iam:PassRole",
                 "kms:TagResource",
                 "kms:UntagResource",
@@ -282,6 +289,8 @@
                 "redshift-serverless:GetNamespace",
                 "redshift-serverless:ListSnapshotCopyConfigurations",
                 "redshift-serverless:CreateSnapshotCopyConfiguration",
+                "redshift-serverless:ListTagsForResource",
+                "redshift-serverless:TagResource",
                 "redshift:GetResourcePolicy",
                 "redshift:PutResourcePolicy",
                 "secretsmanager:CreateSecret",
@@ -294,6 +303,7 @@
             "permissions": [
                 "iam:PassRole",
                 "redshift-serverless:GetNamespace",
+                "redshift-serverless:ListTagsForResource",
                 "redshift:GetResourcePolicy",
                 "redshift-serverless:ListSnapshotCopyConfigurations"
             ]
@@ -320,6 +330,9 @@
                 "redshift-serverless:CreateSnapshotCopyConfiguration",
                 "redshift-serverless:UpdateSnapshotCopyConfiguration",
                 "redshift-serverless:DeleteSnapshotCopyConfiguration",
+                "redshift-serverless:ListTagsForResource",
+                "redshift-serverless:TagResource",
+                "redshift-serverless:UntagResource",
                 "redshift:GetResourcePolicy",
                 "redshift:PutResourcePolicy",
                 "redshift:DeleteResourcePolicy",
@@ -336,6 +349,8 @@
                 "iam:PassRole",
                 "redshift-serverless:DeleteNamespace",
                 "redshift-serverless:GetNamespace",
+                "redshift-serverless:ListTagsForResource",
+                "redshift-serverless:UntagResource",
                 "kms:RetireGrant",
                 "secretsmanager:DescribeSecret",
                 "secretsmanager:DeleteSecret",
@@ -345,7 +360,8 @@
         "list": {
             "permissions": [
                 "iam:PassRole",
-                "redshift-serverless:ListNamespaces"
+                "redshift-serverless:ListNamespaces",
+                "redshift-serverless:ListTagsForResource"
             ]
         }
     },

--- a/aws-redshiftserverless-namespace/resource-role.yaml
+++ b/aws-redshiftserverless-namespace/resource-role.yaml
@@ -30,6 +30,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "iam:CreateServiceLinkedRole"
                 - "iam:PassRole"
                 - "kms:CancelKeyDeletion"
                 - "kms:CreateGrant"
@@ -51,6 +52,9 @@ Resources:
                 - "redshift-serverless:GetNamespace"
                 - "redshift-serverless:ListNamespaces"
                 - "redshift-serverless:ListSnapshotCopyConfigurations"
+                - "redshift-serverless:ListTagsForResource"
+                - "redshift-serverless:TagResource"
+                - "redshift-serverless:UntagResource"
                 - "redshift-serverless:UpdateNamespace"
                 - "redshift-serverless:UpdateSnapshotCopyConfiguration"
                 - "redshift:DeleteResourcePolicy"

--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/CreateHandler.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/CreateHandler.java
@@ -43,7 +43,7 @@ public class CreateHandler extends BaseHandlerStd {
                 return proxy.initiate("AWS-RedshiftServerless-Namespace::Create", proxyClient, progress.getResourceModel(), callbackContext)
                     .translateToServiceRequest(Translator::translateToCreateRequest)
                     .makeServiceCall(this::createNamespace)
-                    .stabilize((_awsRequest, _awsResponse, _client, _model, _context) -> isNamespaceActive(_client, _model, _context))
+                    .stabilize(this::isNamespaceActive)
                     .handleError(this::defaultErrorHandler)
                     .done((_request, _response, _client, _model, _context) -> {
                         callbackContext.setNamespaceArn(_response.namespace().namespaceArn());

--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/ReadHandler.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/ReadHandler.java
@@ -60,6 +60,16 @@ public class ReadHandler extends BaseHandlerStd {
                     return progress;
                 })
                 .then(progress -> {
+                    progress = proxy.initiate("AWS-RedshiftServerless-Namespace::Read::ReadTags", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
+                        .translateToServiceRequest(Translator::translateToReadTagsRequest)
+                        .makeServiceCall(this::readTags)
+                        .handleError(this::defaultErrorHandler)
+                        .done((_request, _response, _client, _model, _context) -> {
+                            return ProgressEvent.progress(Translator.translateFromReadTagsResponse(_response, _model), _context);
+                        });
+                    return progress;
+                })
+                .then(progress -> {
                     return proxy.initiate("AWS-Redshift-ResourcePolicy::Get", redshiftProxyClient, progress.getResourceModel(), callbackContext)
                         .translateToServiceRequest(resourceModelRequest -> Translator.translateToGetResourcePolicy(resourceModelRequest, callbackContext.getNamespaceArn()))
                         .makeServiceCall(this::getNamespaceResourcePolicy)

--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/UpdateTagsRequest.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/UpdateTagsRequest.java
@@ -1,0 +1,17 @@
+package software.amazon.redshiftserverless.namespace;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import software.amazon.awssdk.services.redshiftserverless.model.TagResourceRequest;
+import software.amazon.awssdk.services.redshiftserverless.model.UntagResourceRequest;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateTagsRequest {
+    private TagResourceRequest createNewTagsRequest;
+    private UntagResourceRequest deleteOldTagsRequest;
+}

--- a/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/AbstractTestBase.java
+++ b/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/AbstractTestBase.java
@@ -185,6 +185,7 @@ public class AbstractTestBase {
             .logExports(LOG_EXPORTS)
             .namespaceName(NAMESPACE_NAME)
             .namespace(translateToModelNamespace(NAMESPACE))
+            .tags(Collections.emptyList())
             .snapshotCopyConfigurations(Collections.emptyList())
             .build();
   }
@@ -283,6 +284,7 @@ public class AbstractTestBase {
             .iamRoles(IAM_ROLES)
             .kmsKeyId(KMS_KEY_ID)
             .logExports(LOG_EXPORTS)
+            .tags(Collections.emptyList())
             .namespaceName(NAMESPACE_NAME)
             .namespace(translateToModelNamespace(NAMESPACE))
             .snapshotCopyConfigurations(Collections.emptyList())

--- a/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/CreateHandlerTest.java
+++ b/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/CreateHandlerTest.java
@@ -11,6 +11,8 @@ import software.amazon.awssdk.services.redshiftserverless.model.CreateNamespaceR
 import software.amazon.awssdk.services.redshiftserverless.model.CreateSnapshotCopyConfigurationRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.CreateSnapshotCopyConfigurationResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceRequest;
+import software.amazon.awssdk.services.redshiftserverless.model.ListTagsForResourceRequest;
+import software.amazon.awssdk.services.redshiftserverless.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.ListSnapshotCopyConfigurationsRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.ListSnapshotCopyConfigurationsResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.SnapshotCopyConfiguration;
@@ -78,6 +80,8 @@ public class CreateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(requestResourceModel)
             .build();
+
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().createNamespace(any(CreateNamespaceRequest.class))).thenReturn(getCreateResponseSdk());
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
         when(proxyClient.client().listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class))).thenReturn(getSnapshotCopyConfigurationsResponseSdk());
@@ -107,6 +111,8 @@ public class CreateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(requestResourceModel)
                 .build();
+
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().createNamespace(any(CreateNamespaceRequest.class))).thenReturn(getCreateResponseSdk());
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
         when(proxyClient.client().listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class))).thenReturn(getSnapshotCopyConfigurationsResponseSdk());
@@ -135,6 +141,8 @@ public class CreateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(requestResourceModel)
             .build();
+
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().createNamespace(any(CreateNamespaceRequest.class))).thenReturn(getCreateResponseSdkForManagedAdminPasswords());
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdkForManagedAdminPasswords());
         when(proxyClient.client().listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class))).thenReturn(getSnapshotCopyConfigurationsResponseSdk());
@@ -181,6 +189,8 @@ public class CreateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(requestResourceModel)
                 .build();
+
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().createNamespace(any(CreateNamespaceRequest.class))).thenReturn(getCreateResponseSdk());
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
         when(proxyClient.client().createSnapshotCopyConfiguration(any(CreateSnapshotCopyConfigurationRequest.class)))

--- a/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/ReadHandlerTest.java
+++ b/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/ReadHandlerTest.java
@@ -19,6 +19,8 @@ import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.awssdk.services.redshiftserverless.model.ListSnapshotCopyConfigurationsRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.ListSnapshotCopyConfigurationsResponse;
+import software.amazon.awssdk.services.redshiftserverless.model.ListTagsForResourceRequest;
+import software.amazon.awssdk.services.redshiftserverless.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.RedshiftServerlessException;
 import software.amazon.awssdk.services.redshiftserverless.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.redshiftserverless.model.SnapshotCopyConfiguration;
@@ -96,6 +98,7 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .desiredResourceState(requestResourceModel)
                 .build();
 
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class))).thenReturn(getSnapshotCopyConfigurationsResponseSdk());
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
         when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
@@ -151,6 +154,7 @@ public class ReadHandlerTest extends AbstractTestBase {
             .desiredResourceState(requestResourceModel)
             .build();
 
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
         when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class)))
                 .thenThrow((Throwable) createExceptionWithBuilder(exceptionClass));
@@ -184,6 +188,7 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .desiredResourceState(requestResourceModel)
                 .build();
 
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class))).thenReturn(getSnapshotCopyConfigurationsResponseSdk());
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
         when(redshiftProxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getResourcePolicyResponseSdk());
@@ -217,6 +222,7 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .desiredResourceState(requestResourceModel)
                 .build();
 
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class)))
                 .thenReturn(ListSnapshotCopyConfigurationsResponse.builder()
                         .snapshotCopyConfigurations(Collections.singletonList(SnapshotCopyConfiguration.builder()
@@ -275,6 +281,7 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .desiredResourceState(requestResourceModel)
                 .build();
 
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class)))
                 .thenThrow((Throwable) createExceptionWithBuilder(exceptionClass));
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());

--- a/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/UpdateHandlerTest.java
+++ b/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/UpdateHandlerTest.java
@@ -13,6 +13,8 @@ import software.amazon.awssdk.services.redshiftserverless.model.DeleteSnapshotCo
 import software.amazon.awssdk.services.redshiftserverless.model.GetNamespaceRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.ListSnapshotCopyConfigurationsRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.ListSnapshotCopyConfigurationsResponse;
+import software.amazon.awssdk.services.redshiftserverless.model.ListTagsForResourceRequest;
+import software.amazon.awssdk.services.redshiftserverless.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.redshiftserverless.model.UpdateNamespaceRequest;
 import software.amazon.awssdk.services.redshiftserverless.model.SnapshotCopyConfiguration;
 import software.amazon.awssdk.services.redshiftserverless.model.UpdateSnapshotCopyConfigurationRequest;
@@ -92,6 +94,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .desiredResourceState(requestResourceModel)
             .build();
 
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class))).thenReturn(getSnapshotCopyConfigurationsResponseSdk());
         when(proxyClient.client().updateNamespace(any(UpdateNamespaceRequest.class))).thenReturn(getUpdateResponseSdk());
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
@@ -126,6 +129,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .previousResourceState(prevModel)
                 .build();
 
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class))).thenReturn(getSnapshotCopyConfigurationsResponseSdk());
         when(proxyClient.client().updateNamespace(any(UpdateNamespaceRequest.class))).thenReturn(getUpdateResponseSdk());
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
@@ -168,6 +172,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .policy(NEW_NAMESPACE_RESOURCE_POLICY)
                 .build();
 
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class))).thenReturn(getSnapshotCopyConfigurationsResponseSdk());
         when(proxyClient.client().updateNamespace(any(UpdateNamespaceRequest.class))).thenReturn(getUpdateResponseSdk());
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
@@ -204,6 +209,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .desiredResourceState(requestResourceModel)
             .build();
 
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class))).thenReturn(getSnapshotCopyConfigurationsResponseSdk());
         when(proxyClient.client().updateNamespace(any(UpdateNamespaceRequest.class))).thenReturn(getUpdateResponseSdkForManagedAdminPasswords());
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdkForManagedAdminPasswords());
@@ -241,6 +247,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .desiredResourceState(requestResourceModel)
             .build();
 
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class))).thenReturn(getSnapshotCopyConfigurationsResponseSdk());
         when(proxyClient.client().updateNamespace(any(UpdateNamespaceRequest.class))).thenReturn(getUpdateResponseSdk());
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdk());
@@ -280,6 +287,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .desiredResourceState(requestResourceModel)
             .build();
 
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().listSnapshotCopyConfigurations(any(ListSnapshotCopyConfigurationsRequest.class))).thenReturn(getSnapshotCopyConfigurationsResponseSdk());
         when(proxyClient.client().updateNamespace(any(UpdateNamespaceRequest.class))).thenReturn(getUpdateResponseSdkForManagedAdminPasswords());
         when(proxyClient.client().getNamespace(any(GetNamespaceRequest.class))).thenReturn(getNamespaceResponseSdkForManagedAdminPasswords());
@@ -344,6 +352,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .snapshotRetentionPeriod(-1)
                 .build();
 
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().createSnapshotCopyConfiguration(any(CreateSnapshotCopyConfigurationRequest.class)))
                 .thenReturn(CreateSnapshotCopyConfigurationResponse.builder()
                         .snapshotCopyConfiguration(newSnapshotCopyConfiguration)
@@ -415,6 +424,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .snapshotRetentionPeriod(-1)
                 .build();
 
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().updateSnapshotCopyConfiguration(any(UpdateSnapshotCopyConfigurationRequest.class)))
                 .thenReturn(UpdateSnapshotCopyConfigurationResponse.builder()
                         .snapshotCopyConfiguration(snapshotCopyConfiguration.toBuilder().snapshotRetentionPeriod(2).build())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- This CR contains changes related to supporting tags during update namespace operation. Currently Namespace supports tags during create namespace operation only. We are not able to update tags as the update handler does not support updating the tags.
- This CR also fixes the current issue with contract test failing because they expect the resources which support tagging to include the permissions for tagging operations to work. 

[Testing]

    Unit Tests
    Manually tested that deletion of following namespaces followed expected behaviour
        Executed handlers using local sam cli
        Executed contract tests and verified that they pass


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
