### PR TITLE
Onboard Serverless Tracks to Cloudformation

### DIFF
--- a/aws-redshiftserverless-workgroup/aws-redshiftserverless-workgroup.json
+++ b/aws-redshiftserverless-workgroup/aws-redshiftserverless-workgroup.json
@@ -161,6 +161,18 @@
                 },
                 "PricePerformanceTarget": {
                     "$ref": "#/definitions/PerformanceTarget"
+                },
+                "TrackName": {
+                    "type": "string",
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z0-9_]+$"
+                },
+                "PendingTrackName": {
+                    "type": "string",
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z0-9_]+$"
                 }
             },
             "additionalProperties": false
@@ -290,6 +302,12 @@
             "maxItems": 200,
             "minItems": 0
         },
+        "TrackName": {
+            "type": "string",
+            "maxLength": 256,
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9_]+$"
+        },
         "Workgroup": {
             "description": "Definition for workgroup resource",
             "$ref": "#/definitions/Workgroup"
@@ -328,6 +346,7 @@
         "/properties/Workgroup/ConfigParameters/*/ParameterValue",
         "/properties/Workgroup/SecurityGroupIds",
         "/properties/Workgroup/SubnetIds",
+        "/properties/Workgroup/TrackName",
         "/properties/Workgroup/Status",
         "/properties/Workgroup/Endpoint/Address",
         "/properties/Workgroup/Endpoint/Port",
@@ -345,7 +364,8 @@
         "/properties/MaxCapacity",
         "/properties/ConfigParameters",
         "/properties/SecurityGroupIds",
-        "/properties/SubnetIds"
+        "/properties/SubnetIds",
+        "/properties/TrackName"
     ],
     "primaryIdentifier": [
         "/properties/WorkgroupName"

--- a/aws-redshiftserverless-workgroup/pom.xml
+++ b/aws-redshiftserverless-workgroup/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>redshiftserverless</artifactId>
-            <version>2.29.6</version>
+            <version>1.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/secretsmanager -->
         <dependency>
@@ -189,6 +189,26 @@
                             <sources>
                                 <source>${project.basedir}/target/generated-sources/rpdk</source>
                             </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>2.5.2</version>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/AwsJavaSdk-RedshiftServerless-2.0.jar</file>
+                            <groupId>software.amazon.awssdk</groupId>
+                            <artifactId>redshiftserverless</artifactId>
+                            <version>1.0</version>
+                            <packaging>jar</packaging>
                         </configuration>
                     </execution>
                 </executions>

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/Translator.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/Translator.java
@@ -54,6 +54,7 @@ public class Translator {
                 .publiclyAccessible(model.getPubliclyAccessible())
                 .tags(translateToSdkTags(model.getTags()))
                 .port(model.getPort())
+                .trackName(model.getTrackName())
                 .build();
     }
 
@@ -88,6 +89,7 @@ public class Translator {
                 .pricePerformanceTarget(translateToModelPerformanceTarget(awsResponse.workgroup().pricePerformanceTarget()))
                 .publiclyAccessible(awsResponse.workgroup().publiclyAccessible())
                 .port(awsResponse.workgroup().endpoint().port())
+                .trackName(awsResponse.workgroup().trackName())
                 .workgroup(Workgroup.builder()
                         .workgroupId(awsResponse.workgroup().workgroupId())
                         .workgroupArn(awsResponse.workgroup().workgroupArn())
@@ -103,6 +105,8 @@ public class Translator {
                         .endpoint(translateToModelEndpoint(awsResponse.workgroup().endpoint()))
                         .pricePerformanceTarget(translateToModelPerformanceTarget(awsResponse.workgroup().pricePerformanceTarget()))
                         .publiclyAccessible(awsResponse.workgroup().publiclyAccessible())
+                        .trackName(awsResponse.workgroup().trackName())
+                        .pendingTrackName(awsResponse.workgroup().pendingTrackName())
                         .creationDate(Objects.toString(awsResponse.workgroup().creationDate()))
                         .build())
                 .build();
@@ -172,6 +176,7 @@ public class Translator {
                 .subnetIds(model.getSubnetIds())
                 .securityGroupIds(model.getSecurityGroupIds())
                 .port(model.getPort())
+                .trackName(model.getTrackName())
                 .build();
     }
 

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/Translator.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/Translator.java
@@ -214,6 +214,7 @@ public class Translator {
                 .stream()
                 .map(workgroup -> ResourceModel.builder()
                         .workgroupName(workgroup.workgroupName())
+                        .trackName(workgroup.trackName())
                         .build())
                 .collect(Collectors.toList());
     }

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/UpdateHandler.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/UpdateHandler.java
@@ -123,6 +123,7 @@ public class UpdateHandler extends BaseHandlerStd {
                 .securityGroupIds((List<String>) getDelta.apply(desiredModel.getSecurityGroupIds(), previousModel.getSecurityGroupIds()))
                 .pricePerformanceTarget((PerformanceTarget) getDelta.apply(desiredModel.getPricePerformanceTarget(), previousModel.getPricePerformanceTarget()))
                 .port((Integer) getDelta.apply(desiredModel.getPort(), previousModel.getPort()))
+                .trackName((String) getDelta.apply(desiredModel.getTrackName(), previousModel.getTrackName()))
                 .workgroup(previousModel.getWorkgroup())
                 .build();
     }

--- a/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/AbstractTestBase.java
+++ b/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/AbstractTestBase.java
@@ -45,6 +45,8 @@ public class AbstractTestBase {
     private static final List<String> SECURITY_GROUP_IDS;
     private static final Set<ConfigParameter> CONFIG_PARAMETERS;
     private static final int DEFAULT_PORT;
+    private static final String TRACK_NAME;
+    private static final String PENDING_TRACK_NAME;
     private static final PerformanceTarget PERFORMANCE_TARGET;
 
     private static final List<software.amazon.awssdk.services.redshiftserverless.model.ConfigParameter> RESPONSE_CONFIG_PARAMS;
@@ -68,6 +70,8 @@ public class AbstractTestBase {
         CONFIG_PARAMETERS = Collections.emptySet();
         RESPONSE_CONFIG_PARAMS = Collections.emptyList();
         DEFAULT_PORT = 5439;
+        TRACK_NAME = "DUMMY_TRACK";
+        PENDING_TRACK_NAME = "PENDING_DUMMY_TRACK";
         PERFORMANCE_TARGET_LEVEL = 1;
         PERFORMANCE_TARGET_STATUS = PerformanceTargetStatus.ENABLED.toString();
         PERFORMANCE_TARGET = PerformanceTarget.builder()
@@ -136,6 +140,7 @@ public class AbstractTestBase {
                 .configParameters(CONFIG_PARAMETERS)
                 .port(DEFAULT_PORT)
                 .publiclyAccessible(true)
+                .trackName(TRACK_NAME)
                 .tags(List.of())
                 .pricePerformanceTarget(PERFORMANCE_TARGET)
                 .workgroup(Workgroup.builder()
@@ -151,6 +156,8 @@ public class AbstractTestBase {
                         .creationDate("null")
                         .pricePerformanceTarget(PERFORMANCE_TARGET)
                         .publiclyAccessible(true)
+                        .trackName(TRACK_NAME)
+                        .pendingTrackName(PENDING_TRACK_NAME)
                         .endpoint(Endpoint.builder().port(DEFAULT_PORT).vpcEndpoints(Collections.emptyList()).build())
                         .build())
                 .build();
@@ -179,6 +186,8 @@ public class AbstractTestBase {
                         .subnetIds(SUBNET_IDS)
                         .configParameters(RESPONSE_CONFIG_PARAMS)
                         .publiclyAccessible(true)
+                        .trackName(TRACK_NAME)
+                        .pendingTrackName(PENDING_TRACK_NAME)
                         .pricePerformanceTarget(software.amazon.awssdk.services.redshiftserverless.model.PerformanceTarget.builder()
                                 .status(PERFORMANCE_TARGET_STATUS)
                                 .level(PERFORMANCE_TARGET_LEVEL)
@@ -233,6 +242,7 @@ public class AbstractTestBase {
                 .configParameters(CONFIG_PARAMETERS)
                 .pricePerformanceTarget(PERFORMANCE_TARGET)
                 .publiclyAccessible(true)
+                .trackName(TRACK_NAME)
                 .port(DEFAULT_PORT)
                 .build();
 


### PR DESCRIPTION
Changes: Modified Translator.java, UpdateHandler.java, AbstractTestBase.java as well as the resource_schema and pom.xml to reflect updated RedshiftServerless SDK. When public SDK is released, the pom.xml will be updated again accordingly. This PR is being merged to accelerate contract testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.