### PR TITLE
Fix GetAtt Usage with BaseCapacity and MaxCapacity

### DIFF
--- a/aws-redshiftserverless-workgroup/aws-redshiftserverless-workgroup.json
+++ b/aws-redshiftserverless-workgroup/aws-redshiftserverless-workgroup.json
@@ -351,8 +351,6 @@
         "/properties/Workgroup/CreationDate"
     ],
     "writeOnlyProperties": [
-        "/properties/BaseCapacity",
-        "/properties/MaxCapacity",
         "/properties/ConfigParameters",
         "/properties/SecurityGroupIds",
         "/properties/SubnetIds"

--- a/aws-redshiftserverless-workgroup/docs/configparameter.md
+++ b/aws-redshiftserverless-workgroup/docs/configparameter.md
@@ -41,4 +41,3 @@ _Type_: String
 _Maximum Length_: <code>15000</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-redshiftserverless-workgroup/docs/performancetarget.md
+++ b/aws-redshiftserverless-workgroup/docs/performancetarget.md
@@ -39,4 +39,3 @@ _Required_: No
 _Type_: Integer
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-redshiftserverless-workgroup/docs/tag.md
+++ b/aws-redshiftserverless-workgroup/docs/tag.md
@@ -43,4 +43,3 @@ _Type_: String
 _Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-redshiftserverless-workgroup/docs/workgroup.md
+++ b/aws-redshiftserverless-workgroup/docs/workgroup.md
@@ -8,15 +8,19 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 <pre>
 {
+    "<a href="#basecapacity" title="BaseCapacity">BaseCapacity</a>" : <i>Integer</i>,
+    "<a href="#maxcapacity" title="MaxCapacity">MaxCapacity</a>" : <i>Integer</i>,
     "<a href="#configparameters" title="ConfigParameters">ConfigParameters</a>" : <i>[ <a href="configparameter.md">ConfigParameter</a>, ... ]</i>,
     "<a href="#endpoint" title="Endpoint">Endpoint</a>" : <i><a href="endpoint.md">Endpoint</a></i>,
-    "<a href="#priceperformancetarget" title="PricePerformanceTarget">PricePerformanceTarget</a>" : <i><a href="performancetarget.md">PerformanceTarget</a></i>
+    "<a href="#priceperformancetarget" title="PricePerformanceTarget">PricePerformanceTarget</a>" : <i><a href="performancetarget.md">PerformanceTarget</a></i>,
 }
 </pre>
 
 ### YAML
 
 <pre>
+<a href="#basecapacity" title="BaseCapacity">BaseCapacity</a>: <i>Integer</i>
+<a href="#maxcapacity" title="MaxCapacity">MaxCapacity</a>: <i>Integer</i>
 <a href="#configparameters" title="ConfigParameters">ConfigParameters</a>: <i>
       - <a href="configparameter.md">ConfigParameter</a></i>
 <a href="#endpoint" title="Endpoint">Endpoint</a>: <i><a href="endpoint.md">Endpoint</a></i>
@@ -24,6 +28,22 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 </pre>
 
 ## Properties
+
+#### BaseCapacity
+
+_Required_: No
+
+_Type_: Integer
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### MaxCapacity
+
+_Required_: No
+
+_Type_: Integer
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### ConfigParameters
 


### PR DESCRIPTION
*Issue #, if available:*
Current usage of GetAtt with BaseCapacity and MaxCapacity is broken.

*Description of changes:*
Removed both of these from WriteOnly Properties and allowed all properties to use GetAtt, not just those in ReadOnly.

Confirmed successful contract test with these changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
