### PR TITLE
Fixing tagging edge case bug in namespace and workgroup resource. The bug is getting trigerred if customer doesn't pass any tags during Update operation

### DIFF
--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/Translator.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/Translator.java
@@ -287,14 +287,25 @@ public class Translator {
                                                           final ResourceModel currentResourceState) {
         String resourceArn = currentResourceState.getWorkgroup().getWorkgroupArn();
 
-        List<Tag> toBeCreatedTags = desiredResourceState.getTags() == null ? Collections.emptyList() : desiredResourceState.getTags()
+        // If desiredResourceState.getTags() is null, we should preserve existing tags
+        // This ensures that when CloudFormation doesn't specify tags in the update,
+        // we don't remove existing tags
+        final List<Tag> effectiveDesiredTags;
+        if (desiredResourceState.getTags() == null && currentResourceState.getTags() != null) {
+            // Preserve existing tags by using them as the desired tags
+            effectiveDesiredTags = currentResourceState.getTags();
+        } else {
+            effectiveDesiredTags = desiredResourceState.getTags();
+        }
+
+        List<Tag> toBeCreatedTags = effectiveDesiredTags == null ? Collections.emptyList() : effectiveDesiredTags
                 .stream()
                 .filter(tag -> currentResourceState.getTags() == null || !currentResourceState.getTags().contains(tag))
                 .collect(Collectors.toList());
 
         List<Tag> toBeDeletedTags = currentResourceState.getTags() == null ? Collections.emptyList() : currentResourceState.getTags()
                 .stream()
-                .filter(tag -> desiredResourceState.getTags() == null || !desiredResourceState.getTags().contains(tag))
+                .filter(tag -> effectiveDesiredTags == null || !effectiveDesiredTags.contains(tag))
                 .collect(Collectors.toList());
 
         return UpdateTagsRequest.builder()


### PR DESCRIPTION
Fixing tagging edge case bug in namespace and workgroup resource. 

*Issue #, if available:*

*Description of changes:*

The bug is getting triggered if customer doesn't pass any tags during Update operation. This is causing existing tags to get overridden with empty causing incorrect behavior.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
