### PR TITLE
Fixing the tagging logic for namespace and workgroup continued by merging all stack, resource and system tags together.

### DIFF
--- a/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/CreateHandler.java
+++ b/aws-redshiftserverless-namespace/src/main/java/software/amazon/redshiftserverless/namespace/CreateHandler.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 import java.util.Collections;
 import java.util.Optional;
+import java.util.List;
 
 
 public class CreateHandler extends BaseHandlerStd {
@@ -40,15 +41,22 @@ public class CreateHandler extends BaseHandlerStd {
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
             .then(progress -> {
+                List<Tag>mergedTags = TagHelper.convertToTagList(
+                        TagHelper.mergeTags(
+                                request,
+                                TagHelper.convertToMap(request.getDesiredResourceState().getTags()),
+                                request.getSystemTags(),
+                                TagHelper.convertToMap(progress.getResourceModel().getTags())
+                        ));
                 return proxy.initiate("AWS-RedshiftServerless-Namespace::Create", proxyClient, progress.getResourceModel(), callbackContext)
-                    .translateToServiceRequest(Translator::translateToCreateRequest)
-                    .makeServiceCall(this::createNamespace)
-                    .stabilize(this::isNamespaceActive)
-                    .handleError(this::defaultErrorHandler)
-                    .done((_request, _response, _client, _model, _context) -> {
-                        callbackContext.setNamespaceArn(_response.namespace().namespaceArn());
-                        return ProgressEvent.progress(_model, callbackContext);
-                    });
+                        .translateToServiceRequest((model) -> Translator.translateToCreateRequest(model, mergedTags))
+                        .makeServiceCall(this::createNamespace)
+                        .stabilize(this::isNamespaceActive)
+                        .handleError(this::defaultErrorHandler)
+                        .done((_request, _response, _client, _model, _context) -> {
+                            callbackContext.setNamespaceArn(_response.namespace().namespaceArn());
+                            return ProgressEvent.progress(_model, callbackContext);
+                        });
             })
             .then(progress -> {
                 if (progress.getResourceModel().getNamespaceResourcePolicy() != null) {

--- a/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/AbstractTestBase.java
+++ b/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/AbstractTestBase.java
@@ -301,6 +301,7 @@ public class AbstractTestBase {
             .defaultIamRoleArn(DEFAULT_IAM_ROLE_ARN)
             .iamRoles(IAM_ROLES)
             .logExports(LOG_EXPORTS)
+            .tags(new ArrayList<>())
             .build();
   }
 

--- a/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/UpdateHandlerTest.java
+++ b/aws-redshiftserverless-namespace/src/test/java/software/amazon/redshiftserverless/namespace/UpdateHandlerTest.java
@@ -2,6 +2,7 @@ package software.amazon.redshiftserverless.namespace;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.ArrayList;
 
 import software.amazon.awssdk.services.redshift.RedshiftClient;
 import software.amazon.awssdk.services.redshift.model.*;
@@ -87,6 +88,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceModel responseResourceModel = getUpdateResponseResourceModel();
         ResourceModel prevModel = ResourceModel.builder()
                 .namespaceName(NAMESPACE_NAME)
+                .tags(new ArrayList<>())
                 .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/TagHelper.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/TagHelper.java
@@ -1,14 +1,4 @@
-package software.amazon.redshiftserverless.namespace;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.List;
-import java.util.stream.Collectors;
+package software.amazon.redshiftserverless.workgroup;
 
 import com.google.common.collect.Sets;
 import org.apache.commons.collections.CollectionUtils;
@@ -16,12 +6,10 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import software.amazon.awssdk.awscore.AwsResponse;
 import software.amazon.awssdk.core.SdkClient;
-// TODO: Critical! Please replace the CloudFormation Tag model below with your service's own SDK Tag model
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ProxyClient;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class TagHelper {
     /**

--- a/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/Translator.java
+++ b/aws-redshiftserverless-workgroup/src/main/java/software/amazon/redshiftserverless/workgroup/Translator.java
@@ -287,14 +287,25 @@ public class Translator {
                                                           final ResourceModel currentResourceState) {
         String resourceArn = currentResourceState.getWorkgroup().getWorkgroupArn();
 
-        List<Tag> toBeCreatedTags = desiredResourceState.getTags() == null ? Collections.emptyList() : desiredResourceState.getTags()
+        // If desiredResourceState.getTags() is null, we should preserve existing tags
+        // This ensures that when CloudFormation doesn't specify tags in the update,
+        // we don't remove existing tags
+        final List<Tag> effectiveDesiredTags;
+        if (desiredResourceState.getTags() == null && currentResourceState.getTags() != null) {
+            // Preserve existing tags by using them as the desired tags
+            effectiveDesiredTags = currentResourceState.getTags();
+        } else {
+            effectiveDesiredTags = desiredResourceState.getTags();
+        }
+
+        List<Tag> toBeCreatedTags = effectiveDesiredTags == null ? Collections.emptyList() : effectiveDesiredTags
                 .stream()
                 .filter(tag -> currentResourceState.getTags() == null || !currentResourceState.getTags().contains(tag))
                 .collect(Collectors.toList());
 
         List<Tag> toBeDeletedTags = currentResourceState.getTags() == null ? Collections.emptyList() : currentResourceState.getTags()
                 .stream()
-                .filter(tag -> desiredResourceState.getTags() == null || !desiredResourceState.getTags().contains(tag))
+                .filter(tag -> effectiveDesiredTags == null || !effectiveDesiredTags.contains(tag))
                 .collect(Collectors.toList());
 
         return UpdateTagsRequest.builder()

--- a/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/UpdateHandlerTest.java
+++ b/aws-redshiftserverless-workgroup/src/test/java/software/amazon/redshiftserverless/workgroup/UpdateHandlerTest.java
@@ -116,7 +116,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .desiredResourceState(requestModel)
                 .build();
 
-        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().updateWorkgroup(any(UpdateWorkgroupRequest.class))).thenReturn(updateResponseSdk());
         when(proxyClient.client().getWorkgroup(any(GetWorkgroupRequest.class))).thenReturn(getReadResponseSdk());
         when(proxyClient.client().restoreFromSnapshot(any(RestoreFromSnapshotRequest.class))).thenReturn(
@@ -196,7 +195,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .desiredResourceState(requestModel)
                 .build();
 
-        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().updateWorkgroup(any(UpdateWorkgroupRequest.class))).thenReturn(updateResponseSdk());
         when(proxyClient.client().getWorkgroup(any(GetWorkgroupRequest.class))).thenReturn(getReadResponseSdk());
         when(proxyClient.client().restoreFromRecoveryPoint(any(RestoreFromRecoveryPointRequest.class)))


### PR DESCRIPTION
*Issue
The CV2 tests are failing for out-of-bound-tag related test cases.

*Description of changes:*

Fixing the tagging logic for namespace and workgroup continued by merging all stack, resource and system tags together. Removing the logic to fetch live tags for UpdateHandler.